### PR TITLE
Major Timeseries (+Others) Refactoring

### DIFF
--- a/src/biosignals/Bitalino.py
+++ b/src/biosignals/Bitalino.py
@@ -222,10 +222,14 @@ class Bitalino(BiosignalSource):
         segments = [Bitalino.__read_bit(file, sensor_idx=ch_idx, sensor_names=channels, device=device, **options)
                     for file in all_files[h-1:]]
         for ch, channel in enumerate(channels):
-            samples = [Timeseries.Segment(segment[0][:, ch], initial_datetime=segment[1],
-                                          sampling_frequency=header['sampling rate'])
-                       for segment in segments if segment]
-            new_timeseries = Timeseries(samples, sampling_frequency=header['sampling rate'], ordered=True)
+
+            samples = {segment[1]: segment[0][:, ch] for segment in segments if segment}
+            if len(samples) > 1:
+                new_timeseries = Timeseries.withDiscontiguousSegments(samples, sampling_frequency=header['sampling rate'],
+                                                                      name=channels[ch])
+            else:
+                new_timeseries = Timeseries(tuple(samples.values())[0], tuple(samples.keys())[0], header['sampling rate'],
+                                            name=channels[ch])
             new_dict[channel] = new_timeseries
         return new_dict
 

--- a/src/biosignals/ECG.py
+++ b/src/biosignals/ECG.py
@@ -1,10 +1,16 @@
+from datetime import timedelta
+from typing import Dict
+
+import numpy as np
 from biosppy.plotting import plot_ecg
 from biosppy.signals.tools import get_heart_rate
 from biosppy.signals.ecg import hamilton_segmenter, correct_rpeaks, extract_heartbeats, ecg as biosppyECG
 from numpy import linspace
 
+from biosignals.Timeseries import Timeseries, OverlappingTimeseries
 from src.biosignals.Biosignal import Biosignal
-from src.biosignals.Unit import Volt, Multiplier
+from src.biosignals.Unit import Volt, Multiplier, BeatsPerMinute
+
 
 class ECG(Biosignal):
 
@@ -43,3 +49,164 @@ class ECG(Biosignal):
                               path=save_to,
                               show=show
                             )
+
+    def plot_rpeaks(self, show:bool=True, save_to:str=None):
+        pass  # TODO
+
+    def __r_indices(self, channel:Timeseries, algorithm_method=hamilton_segmenter) -> np.array:
+        """
+        Returns the indices of the R peaks, listed by Segment.
+        E.g. [ [30, 63, 135, ], [23, 49, 91], ... ], where [30, 63, 135, ] are the indices of the 1st Segment.
+        """
+
+        if hasattr(channel.segments[0], 'r_indices'):  # If previously computed, they were stored
+            return [segment._r_indices for segment in channel.segments]
+
+        else:
+            res = []
+            for segment in channel:
+                indices = algorithm_method(segment.samples, channel.sampling_frequency)['rpeaks']  # Compute indices
+                from biosppy.signals.ecg import correct_rpeaks
+                corrected_indices = correct_rpeaks(segment.samples, indices, channel.sampling_frequency)['rpeaks']  # Correct indices
+                res.append(corrected_indices)
+            return res
+
+    def r_timepoints(self, algorithm='hamilton') -> np.array:
+        """
+        Finds the timepoints of the R peaks.
+
+        @param algoritm (optional): The algorithm used to compute the R peaks. Default: Hamilton segmenter.
+
+        @returns: The ordered sequence of timepoints of the R peaks.
+        @rtype: np.array
+
+        Note: Index one channel first.
+        """
+
+        # Get segmenter function
+        if algorithm is 'ssf':
+            from biosppy.signals.ecg import ssf_segmenter
+            segmenter = ssf_segmenter
+        elif algorithm is 'christov':
+            from biosppy.signals.ecg import christov_segmenter
+            segmenter = christov_segmenter
+        elif algorithm is 'engzee':
+            from biosppy.signals.ecg import engzee_segmenter
+            segmenter = engzee_segmenter
+        elif algorithm is 'gamboa':
+            from biosppy.signals.ecg import gamboa_segmenter
+            segmenter = gamboa_segmenter
+        elif algorithm is 'hamilton':
+            segmenter = hamilton_segmenter
+        elif algorithm is 'asi':
+            from biosppy.signals.ecg import ASI_segmenter
+            segmenter = ASI_segmenter
+        else:
+            raise ValueError(
+                "Give an 'algorithm' from the following: 'ssf', 'christov', 'engzee', 'gamboa', 'hamilton', or 'asi'.")
+
+        channel = tuple(self._Biosignal__timeseries.values())[0]
+        r_indices = self.__r_indices(channel, segmenter)
+        all_timepoints = []
+        for x in r_indices:
+            timepoints = np.divide(x, channel.sampling_frequency)  # Transform to timepoints
+            all_timepoints += [timedelta(seconds=tp) for tp in timepoints]  # Append them all
+
+        return np.array(all_timepoints)
+
+    def heartbeats(self, before=0.2, after=0.4):
+        """
+        Segment the signal by heartbeats.
+        Works like a Segmenter, except output Timeseries is not necessarily equally segmented.
+
+        Parameters
+        ----------
+        before : float, optional
+            Window size to include before the R peak (seconds).
+        after : int, optional
+            Window size to include after the R peak (seconds).
+
+        Returns
+        -------
+        heartbeats : ECG
+            Biosignal segmented where each Segment is a heartbeat.
+
+        """
+
+        from biosppy.signals.ecg import extract_heartbeats
+
+        all_heartbeat_channels = {}
+        for channel_name in self.channel_names:
+            channel = self._Biosignal__timeseries[channel_name]
+            all_heartbeats = []
+            r_indices = self.__r_indices(channel)
+            for segment, indices in zip(channel, r_indices):
+                heartbeats = extract_heartbeats(segment.samples, indices, channel.sampling_frequency, before, after)['templates']
+                time_offset = segment.initial_datetime - timedelta(seconds=before)
+                for hb, r_index in zip(heartbeats, indices):
+                    all_heartbeats.append(Timeseries.Segment(hb, timedelta(seconds=r_index/channel.sampling_frequency)+time_offset, channel.sampling_frequency))
+
+            all_heartbeat_channels[channel_name] = OverlappingTimeseries(all_heartbeats, True, channel.sampling_frequency, channel.units, 'Heartbeats of ' + channel.name, equally_segmented=False)
+
+        return ECG(all_heartbeat_channels, self.source, self._Biosignal__patient, self.acquisition_location, 'Heartbeats of ' + self.name)
+
+    def hr(self, smooth_length: float = None):
+        """
+        Transform ECG signal to instantaneous heart rate.
+
+         Parameters
+        ----------
+        smooth_length : float, optional
+            Length of smoothing window. If not given, no smoothing is performed on the instantaneous heart rate.
+
+        Returns
+        -------
+        hr : HR
+            Pseudo-Biosignal where samples are the instantaneous heart rate at each timepoint.
+        """
+
+        from biosppy.signals.tools import get_heart_rate
+
+        all_hr_channels = {}
+        for channel_name in self.channel_names:
+            channel = self._Biosignal__timeseries[channel_name]
+            all_hr = []
+            for segment in channel:
+                indices = np.array([int((timepoint - segment.initial_datetime).total_seconds() * self.sampling_frequency) for timepoint in self.r_timepoints])
+                hr = get_heart_rate(indices, channel.sampling_frequency, smooth = (smooth_length is not None), size=smooth_length)['heart_rate']
+                all_hr.append(Timeseries.Segment(hr, segment.initial_datetime, channel.sampling_frequency))
+
+            all_hr_channels[channel_name] = Timeseries(all_hr, True, channel.sampling_frequency, BeatsPerMinute(), 'Heart Rate of ' + channel.name, equally_segmented=False)
+
+        from biosignals.HR import HR
+        return HR(all_hr_channels, self.source, self._Biosignal__patient, self.acquisition_location, 'Heart Rate of ' + self.name, original_signal=self)
+
+    def nni(self):
+        """
+        Transform ECG signal to R-R peak interval signal.
+
+        Parameters
+        ----------
+        smooth_length : float, optional
+            Length of smoothing window. If not given, no smoothing is performed on the instantaneous heart rate.
+
+        Returns
+        -------
+        hr : HR
+            Pseudo-Biosignal where samples are the instantaneous heart rate at each timepoint.
+        """
+
+        all_nni_channels = {}
+        for channel_name in self.channel_names:
+            channel = self._Biosignal__timeseries[channel_name]
+            all_nii = []
+            for segment in channel:
+                indices = np.array([int((timepoint - segment.initial_datetime).total_seconds() * self.sampling_frequency) for timepoint in self.r_timepoints])
+                nni = np.diff(indices)
+                all_nii.append(Timeseries.Segment(nni, segment.initial_datetime, channel.sampling_frequency))
+
+            all_nni_channels[channel_name] = Timeseries(all_nii, True, channel.sampling_frequency, None, 'NNI of ' + channel.name, equally_segmented=channel.is_equally_segmented)
+
+        return NNI(all_nni_channels, self.source, self._Biosignal__patient, self.acquisition_location, 'NNI of ' + self.name, original_signal=self)
+
+

--- a/src/biosignals/Frequency.py
+++ b/src/biosignals/Frequency.py
@@ -1,0 +1,19 @@
+class Frequency(float):
+
+    def __init__(self, value:float):
+        self.value = float(value)
+
+    def __str__(self):
+        return str(self.value) + ' Hz'
+
+    def __eq__(self, other):
+        if isinstance(other, float):
+            return other == self.value
+        elif isinstance(other, Frequency):
+            return other.value == self.value
+
+    def __float__(self):
+        return self.value
+
+    def __copy__(self):
+        return Frequency(self.value)

--- a/src/biosignals/HEM.py
+++ b/src/biosignals/HEM.py
@@ -69,10 +69,13 @@ class HEM(BiosignalSource):
         new_dict = {}
         # TODO ADD UNITS TO TIMESERIES
         for ch in range(len(channels)):
-            segments = [Timeseries.Segment(trc_data[0][ch], initial_datetime=trc_data[1], sampling_frequency=sfreq)
-                        for trc_data in all_trc]
-            new_timeseries = Timeseries(segments=segments, sampling_frequency=sfreq, ordered=True)
+            segments = {trc_data[1]: trc_data[0][ch] for trc_data in all_trc}
+            if len(segments) > 1:
+                new_timeseries = Timeseries.withDiscontiguousSegments(segments, sampling_frequency=sfreq, name=channels[ch])
+            else:
+                new_timeseries = Timeseries(tuple(segments.values())[0], tuple(segments.keys())[0], sfreq,  name=channels[ch])
             new_dict[channels[ch]] = new_timeseries
+
         return new_dict
 
     @staticmethod

--- a/src/biosignals/HR.py
+++ b/src/biosignals/HR.py
@@ -1,5 +1,8 @@
+from src.biosignals.PPG import PPG
+from src.biosignals.ECG import ECG
 from src.biosignals.Biosignal import Biosignal
 
 class HR(Biosignal):
-    def __init__(self, timeseries, source=None, patient=None, acquisition_location=None, name=None):
+    def __init__(self, timeseries, source=None, patient=None, acquisition_location=None, name=None, original_signal:ECG|PPG=None):
         super(HR, self).__init__(timeseries, source, patient, acquisition_location, name)
+        self.__original_signal = original_signal

--- a/src/biosignals/HSM.py
+++ b/src/biosignals/HSM.py
@@ -66,10 +66,11 @@ class HSM(BiosignalSource):
         all_edf = list(map(HSM.__read_edf, all_files))
         new_dict = {}
         for ch in range(len(channels)):
-            segments = [Timeseries.Segment(edf_data[0][ch], initial_datetime=edf_data[1], sampling_frequency=sfreq)
-                        for edf_data in all_edf]
-            # samples = {edf_data[0]: edf_data[1][ch] for edf_data in segments}
-            new_timeseries = Timeseries(segments, sampling_frequency=sfreq, name=channels[ch], ordered=True)
+            segments = {edf_data[1]: edf_data[0][ch] for edf_data in all_edf}
+            if len(segments) > 1:
+                new_timeseries = Timeseries.withDiscontiguousSegments(segments, sampling_frequency=sfreq, name=channels[ch])
+            else:
+                new_timeseries = Timeseries(tuple(segments.values())[0], tuple(segments.keys())[0], sfreq, name=channels[ch])
             new_dict[channels[ch]] = new_timeseries
         return new_dict
 

--- a/src/biosignals/MITDB.py
+++ b/src/biosignals/MITDB.py
@@ -86,13 +86,15 @@ class MITDB(BiosignalSource):
         all_edf = list(map(MITDB.__read_dat, all_files))
         new_dict = {}
         for ch in range(len(channels)):
-            segments = [Timeseries.Segment(edf_data[0][:, ch], initial_datetime=edf_data[1], sampling_frequency=sfreq)
-                        for edf_data in all_edf]
+            segments = {edf_data[1]: edf_data[0][:, ch] for edf_data in all_edf}
             unit = Volt(Multiplier.m) if 'mV' in units[ch] else None
             name = BodyLocation.MLII if channels[ch].strip() == 'MLII' else BodyLocation.V5 if channels[ch].strip() == 'V5' else channels[ch]
-            print(f'{ch} channel: {name}')
-            new_timeseries = Timeseries(segments, sampling_frequency=sfreq, name=channels[ch], units=unit, ordered=True)
+            if len(segments) > 1:
+                new_timeseries = Timeseries.withDiscontiguousSegments(segments, sampling_frequency=sfreq, name=channels[ch], units=unit)
+            else:
+                new_timeseries = Timeseries(tuple(segments.values())[0], tuple(segments.keys())[0], sfreq, name=channels[ch], units=unit)
             new_dict[channels[ch]] = new_timeseries
+
         return new_dict
 
     @staticmethod

--- a/src/biosignals/Seer.py
+++ b/src/biosignals/Seer.py
@@ -82,14 +82,16 @@ class Seer(BiosignalSource):
             channels, sfreq, units = Seer.__read_file(device_files[0], metadata=True)
             all_edf = list(map(Seer.__read_file, device_files))
             for ch in range(len(channels)):
-                segments = [Timeseries.Segment(edf_data[0][ch], initial_datetime=edf_data[1], sampling_frequency=sfreq)
-                            for edf_data in all_edf]
+                segments = {edf_data[1]: edf_data[0][ch] for edf_data in all_edf}
                 unit = units
                 name = f'{channels[ch]} from {device.split("-")[0]}'
                 dict_key = f'{device.split("-")[0]}-{channels[ch].upper()}' if len(devices) > 1 else channels[ch].upper()
-                print(f'{ch} channel: {name}')
-                new_timeseries = Timeseries(segments, sampling_frequency=sfreq, name=name, units=unit, ordered=True)
+                if len(segments) > 1:
+                    new_timeseries = Timeseries.withDiscontiguousSegments(segments, sampling_frequency=sfreq, name=name, units=unit)
+                else:
+                    new_timeseries = Timeseries(tuple(segments.values())[0], tuple(segments.keys())[0], sfreq, name=name, units=unit)
                 new_dict[dict_key] = new_timeseries
+
         return new_dict
 
     @staticmethod

--- a/src/biosignals/Timeseries.py
+++ b/src/biosignals/Timeseries.py
@@ -1,26 +1,225 @@
-from datetime import datetime, timedelta
+# -*- encoding: utf-8 -*-
 
+# ===================================
+
+# IT - PreEpiSeizures
+
+# Package: biosignals
+# File: Timeseries
+# Description: Classes conceptualizing mathematical timeseries and their behaviour.
+
+# Contributors: João Saraiva, Mariana Abreu
+# Created: 20/04/2022
+# Last Updated: 21/07/2022
+
+# ===================================
+
+from datetime import datetime, timedelta
+from typing import List, Iterable, Collection, Dict, Tuple, Callable
+
+import matplotlib.pyplot as plt
+from biosppy.signals.tools import power_spectrum
 from datetimerange import DateTimeRange
 from dateutil.parser import parse as to_datetime
-from typing import List, Iterable, Collection, Dict, Tuple
-from numpy import array
-from biosppy.signals.tools import power_spectrum
+from numpy import array, append, ndarray, divide
 from scipy.signal import resample
-import matplotlib.pyplot as plt
 
 from src.biosignals.Event import Event
-from src.processing.FrequencyDomainFilter import Filter
+from src.biosignals.Frequency import Frequency
 from src.biosignals.Unit import Unit
+from src.processing.FrequencyDomainFilter import Filter
+
 
 class Timeseries():
+    """
+    A Timeseries is a sequence of data points that occur in successive order over some period of time.
+    In a Biosignal, one Timeseries' data points are the measurement of a biological variable, in some unit, taken from a
+    sensor or channel. This data points are often called samples, and are acquired at fixed sampling frequency.
 
-    class Segment():
-        def __init__(self, samples:array, initial_datetime:datetime, sampling_frequency:float, is_filtered:bool=False):
-            self.__samples = samples
+    To each time point of a Timeseries' domain corresponds one and only one sample. However, a Timeseries might be
+    contiguous if a sample was acquired at every sampling time point, or discontiguous if there were interruptions. Each
+    interval/sequence of contiguous samples is called a Segment, but those are managed internally.
+
+    Constructors / Initializers
+    ______________
+
+    Timeseries: default
+        Instantiates a Timeseries with a contiguous sequence of samples.
+
+    Timeseries.withDiscontiguousSegments
+        Instantiates a Timeseries with discontiguous sequences of samples.
+
+
+    Properties:
+    ______________
+
+    name: str
+        The name of the Timeseries, if any.
+
+    samples: array  # FIXME
+        Contiguous or discontiguous sequence of samples.
+
+    sampling_frequency: float
+        The frequency at which the samples were acquired, in Hz.
+
+    units: Unit
+        The physical unit at which the samples should be interpreted.
+
+    events: tuple[Event]
+        The events timely associated to the Timeseries.
+
+    initial_datetime: datetime
+        The date and time of the first sample.
+
+    final_datetime: datetime
+        The date and time of the last sample.
+
+    duration: timedelta
+        The total time of acquired samples, excluding interruptions.
+
+    domain: tuple[DateTimeRange]
+        The intervals of date and time in which the Timeseries is defined, i.e., samples were acquired.
+
+    is_equally_segmented: bool
+        The logic value stating if each interval in the domain has the same duration.
+
+    segment_duration: timedelta:
+        Duration of all segments, if is_equally_segmented is True.
+
+
+    Built-ins:
+    ______________
+
+    len: Returns the total number of samples.
+
+    copy: Copies all Timeseries' content.
+
+    iter: Returns an iterator over the samples of all Timeseries' Segments.
+
+    in: Returns True if a date, time or event is contained in the Timeseries.
+
+    [] : Indexes by date, time or events.
+
+    + : Adds Timeseries.
+
+    += : Appends more samples to the last Timeseries' Segment.
+
+    Methods:
+    ______________
+
+    append(datetime, array):
+        Appends a new sequence of samples in a separate Segment.
+
+    associate(Event):
+        Timely associates a given Event to the Timeseries.
+
+    dissociate(str):
+        Removes any association the Timeseries has with an Event with the given name.
+
+    filter(Filter):
+        Filters the Timeseries with the given design.
+
+    undo_filters():
+        Reverts the effect of all filters.
+
+    plot():
+        Plots the Timeseries amplitude over time, with all its interruptions, if any.
+
+    plot():
+        Plots the Timeseries frequency spectrum.
+
+    ______________
+
+    Full documentation in:
+    https://github.com/jomy-kk/IT-LongTermBiosignals/wiki/%5BClass%5D-Timeseries
+    """
+
+    # ===================================
+    # Class: Segment
+
+    class __Segment():
+        """
+        A Segment is an interrupted sequence of samples.
+        This is an internal class of Timeseries, for its internal management, and should not be used outside Timeseries.
+
+        Properties:
+        ______________
+
+        samples: array
+            Sequence of samples, acquired at a fixed sampling rate.
+
+        raw_samples: array
+            Original samples, without application of filters or other operations in-place.
+
+        initial_datetime: datetime
+            The date and time of the first sample.
+
+        final_datetime: datetime
+            The date and time of the last sample.
+
+        duration: timedelta
+            The total time of acquired samples, i.e., final_datetime - initial_datetime.
+
+        is_filtered: bool
+            The logic value stating if the samples have been filtered.
+
+
+        Built-ins:
+        ______________
+
+        len: Returns the total number of samples.
+
+        copy: Copies all Timeseries' content.
+
+        in: Returns True if a date, time or event is contained in the Timeseries.
+
+        [] : Indexes by sample index.
+
+        += : Appends more samples.
+
+        <, >, <=, >= : State if onw Timeseries come before another.
+
+
+        Methods:
+        ______________
+
+        adjacent(Segment):
+            Returns whether two Segments are adjacent in time.
+
+        overlap(Segment):
+            Returns whether two Segments overlap in time.
+
+        """
+
+        def __init__(self, samples: ndarray, initial_datetime: datetime, sampling_frequency: Frequency,
+                     is_filtered: bool = False):
+            """
+            A Segment is an interrupted sequence of samples.
+
+            Parameters
+            ------------
+            samples: ndarray
+                The samples to store.
+
+            initial_datetime: datetime
+                The date and time of the first sample.
+
+            sampling_frequency: Frequency
+                Reference to the sampling frequency object of the respective Timeseries.
+
+            is_filtered: bool
+                If samples have been filtered.
+            """
+
+            self.__samples = samples if isinstance(samples, ndarray) else array(samples)
             self.__initial_datetime = initial_datetime
-            self.__final_datetime = self.initial_datetime + timedelta(seconds=len(samples)/sampling_frequency)
+            self.__final_datetime = self.initial_datetime + timedelta(seconds=len(samples) / sampling_frequency)
             self.__raw_samples = samples  # if some filter is applied to a Timeseries, the raw version of each Segment should be saved here
             self.__is_filtered = is_filtered
+            self.__sampling_frequency = sampling_frequency
+
+        # ===================================
+        # Properties
 
         @property
         def samples(self) -> array:
@@ -46,112 +245,272 @@ class Timeseries():
         def is_filtered(self) -> bool:
             return self.__is_filtered
 
+        # ===================================
+        # Built-ins
+
         def __len__(self):
             return len(self.__samples)
 
+        def __iadd__(self, other: ndarray | list):
+            self.__samples = append(self.__samples, other)
+
+        def __contains__(self, item):  # Operand 'in' === belongs to
+            if isinstance(item, datetime):
+                return self.initial_datetime <= item < self.final_datetime
+            if isinstance(item, type(self)):  # item is a Segment
+                # A Segment contains other Segment if its start is less than the other's and its end is greater than the other's.
+                return self.initial_datetime < item.initial_datetime and self.final_datetime > item.final_datetime
+
         def __getitem__(self, position):
             '''The built-in slicing and indexing (segment[x:y]) operations.'''
-            return self.__samples[position]
+            if isinstance(position, (int, tuple)):
+                return self.__samples[position]
+            elif isinstance(position, slice):
+                if position.start is None:
+                    new_initial_datetime = self.__initial_datetime
+                else:
+                    new_initial_datetime = self.__initial_datetime + timedelta(
+                        seconds=position.start / self.__sampling_frequency.value)
+                return self._new(samples=self.__samples[position], initial_datetime=new_initial_datetime,
+                                 raw_samples=self.__raw_samples[position])
 
-        def __lt__(self, other):  # A Segment comes before other Segment if its end is less than the other's start.
+        # ===================================
+        # Binary Logic using Time
+
+        def __lt__(self, other):
+            """A Segment comes before other Segment if its end is less than the other's start."""
             return self.final_datetime < other.initial_datetime
 
         def __le__(self, other):
             return self.final_datetime <= other.initial_datetime
 
-        def __gt__(self, other):  # A Segment comes after other Segment if its start is greater than the other's end.
+        def __gt__(self, other):
+            """A Segment comes after other Segment if its start is greater than the other's end."""
             return self.initial_datetime > other.final_datetime
 
         def __ge__(self, other):
             return self.initial_datetime >= other.final_datetime
 
-        def __eq__(self, other):  # A Segment corresponds to the same time period than other Segment if their start and end are equal.
+        def __eq__(self, other):
+            """A Segment corresponds to the same time period than other Segment if their start and end are equal."""
             return self.initial_datetime == other.initial_datetime and self.final_datetime == other.final_datetime
 
         def __ne__(self, other):
             return not self.__eq__(other)
 
-        def __contains__(self, item):  # Operand 'in' === belongs to
-            if isinstance(item, datetime):
-                return self.initial_datetime <= item < self.final_datetime
-            if isinstance(item, Timeseries.Segment):
-                # A Segment contains other Segment if its start is less than the other's and its end is greater than the other's.
-                return self.initial_datetime < item.initial_datetime and self.final_datetime > item.final_datetime
-
-        def overlaps(self, other):  # A Segment overlaps other Segment if its end comes after the other's start, or its start comes before the others' end, or vice versa.
+        def overlaps(self, other):
+            """A Segment overlaps other Segment if its end comes after the other's start, or its start comes before the others' end, or vice versa."""
             if self <= other:
                 return self.final_datetime > other.initial_datetime
             else:
                 return self.initial_datetime < other.final_datetime
 
         def adjacent(self, other):
-            '''
-            Returns True if the Segments' start or end touch.
-            '''
+            """Returns True if the Segments' start or end touch."""
             return self.final_datetime == other.initial_datetime or self.initial_datetime == other.final_datetime
 
+        # ===================================
+        # INTERNAL USAGE - Accept Methods
 
-        def _accept_filtering(self, filter_design:Filter):
+        # General-purpose
+
+        def _apply_operation(self, operation, **kwargs):
+            """
+            Protected Access: For use of this module.
+            Applies operation in-place to its samples.
+            """
+            self.__samples = operation(self.__samples, **kwargs)
+
+        def _apply_operation_and_return(self, operation, **kwargs):
+            """
+            Protected Access: For use of this module.
+            Applies operation to a copy of its samples and returns the output.
+            """
+            return operation(self.__samples.copy(), **kwargs)
+
+        # Purpose-specific
+
+        def _accept_filtering(self, filter_design: Filter):
+            """
+            Protected Access: For use of this module.
+            Applies a filter to its samples, given a design.
+            """
             res = filter_design._visit(self.__samples)  # replace with filtered samples
             self.__samples = res
             self.__is_filtered = True
 
         def _restore_raw(self):
+            """
+            Protected Access: For use of this module.
+            Restores the raw samples.
+            """
             if self.is_filtered:
                 self.__samples = self.__raw_samples
                 self.__is_filtered = False
 
-        def _resample(self, old_frequency, new_frequency):
-            n_samples = int(new_frequency * len(self) / old_frequency)
+        def _resample(self, new_frequency: Frequency):
+            """
+            Protected Access: For use of this module.
+            Resamples the samples to a new sampling frequency.
+            """
+            n_samples = int(new_frequency * len(self) / self.__sampling_frequency)
             self.__samples = resample(self.__samples, num=n_samples)
-            self.__final_datetime = self.initial_datetime + timedelta(seconds=len(self) / new_frequency)
+            self.__sampling_frequency = new_frequency
+            self.__final_datetime = self.initial_datetime + timedelta(seconds=len(self) / new_frequency.value)
 
-        def _apply_operation(self, operation, **kwargs):
-            self.__samples = operation(self.__samples, **kwargs)
+        # ===================================
+        # INTERNAL USAGE - Make similar copies or itself
 
+        def __copy__(self):
+            """ Creates an exact copy of the Segment contents and returns the new object. """
+            new = type(self)(self.samples.copy(), self.initial_datetime, self.__sampling_frequency.__copy__(),
+                             self.is_filtered)
+            new._Segment__raw_samples = self.__raw_samples
+            return new
 
+        def _new(self, samples: array = None, initial_datetime: datetime = None, sampling_frequency: Frequency = None,
+                 is_filtered: bool = False, raw_samples: array = None):
+            """
+            Protected Access: For use of this module.
 
-    def __init__(self, segments: List[Segment], ordered:bool, sampling_frequency:float, units:Unit=None, name:str=None, equally_segmented=False):
-        ''' Receives a list of non-overlapping Segments and a sampling frequency common to all Segments.
-        If they are timely ordered, pass ordered=True, otherwise pass ordered=False.
-        Additionally, it can receive the sample units and a name, if needed.'''
+            Creates a similar copy of the Segment's contents and returns the new object.
+            The value of any field can be changed, when explicitly given a new value for it. All others will be copied.
 
-        # Order the Segments, if necessary
-        # Order the Segments, if necessary
-        if not ordered:
-            self.__segments = sorted(segments)
+            :param samples: Different samples. Optional.
+            :param initial_datetime: A different date and time of the first sample. Optional.
+            :param sampling_frequency: A different sampling frequency of the samples. Optional.
+            :param is_filtered: Alter the filtered state. Optional.
+            :param raw_samples: Different raw samples. Optional.
+
+            Note: If none of these parameters is given, this method is equivalent to '__copy__'.
+
+            :return: A new Segment with the given fields changed. All other contents shall remain the same.
+            :rtype: Segment
+            """
+            samples = self.__samples.copy() if samples is None else samples  # copy
+            initial_datetime = self.__initial_datetime if initial_datetime is None else initial_datetime
+            sampling_frequency = self.__sampling_frequency.__copy__() if sampling_frequency is None else sampling_frequency
+            is_filtered = self.__is_filtered if is_filtered is None else is_filtered
+            raw_samples = self.__raw_samples if raw_samples is None else raw_samples  # no copy
+
+            new = type(self)(samples, initial_datetime, sampling_frequency, is_filtered)
+            new._Segment__raw_samples = raw_samples
+            return new
+
+        def _apply_operation_and_new(self, operation: Callable, initial_datetime: datetime = None,
+                                     sampling_frequency: Frequency = None, **kwargs):
+            """
+            Protected Access: For use of this module.
+
+            Similarly to '_apply_operation', it applies 'operation' but saves the resulting samples in a new Segment,
+            which is returned.
+
+            :param operation: A procedure to be executed over the samples. Its First argument must expect a ndarray.
+            :param initial_datetime: A different date and time the first sample might have after the operation.
+            :param sampling_frequency: A different sampling frequency the samples might have after the operation.
+            :param kwargs: Additional arguments to pass when calling 'operation'.
+
+            :return: A new Segment with the samples outputted by the operation. All other contents shall remain the same,
+            except for initial_datetime and sampling_frequency if new values were given.
+            :rtype: Segment
+            """
+            samples = operation(self.__samples.copy(), **kwargs)
+            return self._new(samples, initial_datetime=initial_datetime, sampling_frequency=sampling_frequency)
+
+    # ===================================
+    # Class: Timeseries
+
+    def __init__(self, samples: ndarray | list | tuple, initial_datetime: datetime, sampling_frequency: float,
+                 units: Unit = None, name: str = None):
+        """
+        Give a sequence of contiguous samples, i.e. without interruptions, and the datetime of the first sample.
+        If there are interruptions, append the remaining segments using the 'append' method.
+        It also receives the sampling frequency of the samples.
+        Additionally, it can receive the samples' units and a name, if needed.
+
+        Parameters
+        ------------
+        samples: ndarray | list | tuple
+            The samples to store, without interruptions.
+
+        initial_datetime: datetime
+            The date and time of the first sample.
+
+        sampling_frequency: float | Frequency
+            The frequency at which the samples where sampled.
+
+        units: Unit
+            The physical units of the variable measured.
+
+        name: str
+            A symbolic name for the Timeseries. It is mentioned in plots, reports, error messages, etc.
+        """
+
+        # Shortcut: Check if being copied
+        if isinstance(samples, list) and isinstance(samples[0], Timeseries.__Segment):
+            self.__segments = samples
+
         else:
-            self.__segments = segments
+            # Creat first Segment
+            samples = array(samples) if not isinstance(samples, ndarray) else samples
+            sampling_frequency = sampling_frequency if isinstance(sampling_frequency,
+                                                                  Frequency) else Frequency(sampling_frequency)
+            segment = Timeseries.__Segment(samples, initial_datetime, sampling_frequency)
+            self.__segments = [segment, ]
 
-        # Check if Segments overlap
-        if not isinstance(self, OverlappingTimeseries):
-            for i in range(1, len(self.__segments)):
-                print(self.__segments[i-1].overlaps(self.__segments[i]))
-                print(self.__segments[i-1].final_datetime)
-                print(self.__segments[i].initial_datetime)
-                if self.__segments[i-1].overlaps(self.__segments[i]):
-                    if name is not None:
-                        raise AssertionError(f"Overlapping Segments in Timeseries '{name}'. To each timepoint must correspond one and only one sample, like a function.")
-                    else:
-                        raise AssertionError("Overlapping Segments not allowed. To each timepoint must correspond one and only one sample, like a function.")
-
-        # Save metadata
+        # Metadata
         self.__sampling_frequency = sampling_frequency
         self.__units = units
-        self.__initial_datetime = self.__segments[0].initial_datetime  # Is the initial datetime of the first Segment.
-        self.__final_datetime = self.__segments[-1].final_datetime  # Is the final datetime of the last Segment.
-
         self.__name = name
-
-        self.__is_equally_segmented = equally_segmented
-
         self.__associated_events = {}
 
+        # Control Flags
+        self.__is_equally_segmented = True  # Because there's only 1 Segment
 
-    # Getters and Setters
+    @classmethod
+    def withDiscontiguousSegments(cls, segments_by_time: Dict[datetime, ndarray | list | tuple],
+                                  sampling_frequency: float, units: Unit = None, name: str = None):
+        """
+        Give a dictionary of discontiguous sequences of samples, keyed by their initial date and time.
+        It also receives the sampling frequency of the samples.
+        Additionally, it can receive the samples' units and a name, if needed.
 
-    def __len__(self):
-        return sum([len(seg) for seg in self.__segments])
+        Parameters
+        ------------
+        samples: dict [datetime, ndarray | list | tuple]
+            The sequence of samples to store as separate Segments, in the format { datetime: [, ... ], ... }.
+
+        initial_datetime: datetime
+            The date and time of the first sample.
+
+        sampling_frequency: float | Frequency
+            The frequency at which the samples where sampled.
+
+        units: Unit
+            The physical units of the variable measured.
+
+        name: str
+            A symbolic name for the Timeseries. It is mentioned in plots, reports, error messages, etc.
+        """
+
+        if len(segments_by_time) < 2:
+            raise TypeError("Use the regular initializer to instantiate a Timeseries with 1 contiguous segment.")
+
+        # Sort the segments
+        ordered_arrays = sorted(segments_by_time.items())  # E.g. [ (datetime, array), (.., ..), .. ]
+
+        # Create Timeseries with the first Segment
+        initial_datetime, first_array = ordered_arrays[0]
+        new = cls(first_array, initial_datetime, sampling_frequency, units, name)
+
+        # Append the remaining Segments
+        for datetime, array in ordered_arrays[1:]:
+            new.append(datetime, array)
+
+        return new
+
+    # ===================================
+    # Properties
 
     @property
     def segments(self) -> list:
@@ -159,43 +518,69 @@ class Timeseries():
 
     @property
     def initial_datetime(self) -> datetime:
-        return self.__initial_datetime
+        """The date and time of the first sample."""
+        return self.__segments[0].initial_datetime  # Is the initial datetime of the first Segment.
 
     @property
     def final_datetime(self) -> datetime:
-        return self.__final_datetime
+        """The date and time of the last sample."""
+        return self.__segments[-1].final_datetime  # Is the final datetime of the last Segment.
 
     @property
     def domain(self) -> Tuple[DateTimeRange]:
+        """The intervals of date and time in which the Timeseries is defined, i.e., samples were acquired."""
         return tuple([DateTimeRange(segment.initial_datetime, segment.final_datetime) for segment in self])
 
     @property
-    def sampling_frequency(self):
-        return self.__sampling_frequency
+    def sampling_frequency(self) -> float:
+        """The frequency at which the samples were acquired, in Hz."""
+        return self.__sampling_frequency.value
 
     @property
     def units(self):
+        """The physical unit at which the samples should be interpreted."""
         return self.__units
 
     @property
     def name(self):
+        """The name of the Timeseries, if any."""
         return self.__name if self.__name != None else "No Name"
 
     @name.setter
-    def name(self, name:str):
+    def name(self, name: str):
+        """Set or reset a name for the Timeseries."""
         self.__name = name
 
     @property
     def is_equally_segmented(self) -> bool:
+        """The logic value stating if each interval in the domain has the same duration."""
         return self.__is_equally_segmented
 
     @property
-    def events(self):
-        '''Tuple of associated Events, ordered by datetime.'''
+    def segment_duration(self) -> timedelta:
+        """Duration of segments, if is_equally_segmented is True."""
+        if not self.is_equally_segmented:
+            raise AttributeError("There is no segment duration because this Timeseries was not equally segmented.")
+        else:
+            return self.__segments[0].duration
+
+    @property
+    def events(self) -> Tuple[Event]:
+        """The events timely associated to the Timeseries, timely ordered."""
         return tuple(sorted(self.__associated_events.values()))
+
+    # ===================================
+    # Built-ins
+
+    def __len__(self):
+        return sum([len(seg) for seg in self.__segments])
 
     def __iter__(self) -> Iterable:
         return self.__segments.__iter__()
+
+    def __contains__(self, item):
+        '''Checks if event occurs in Timeseries.'''
+        return item in self.__associated_events
 
     def __getitem__(self, item):
         '''The built-in slicing and indexing ([x:y]) operations.'''
@@ -208,10 +593,12 @@ class Timeseries():
         if isinstance(item, slice):
             if item.step is not None:
                 raise IndexError("Indexing with step is not allowed for Timeseries. Try resampling it first.")
-            initial = to_datetime(item.start) if isinstance(item.start, str) else self.initial_datetime if item.start is None else item.start
-            final = to_datetime(item.stop) if isinstance(item.stop, str) else self.final_datetime if item.stop is None else item.stop
+            initial = to_datetime(item.start) if isinstance(item.start,
+                                                            str) else self.initial_datetime if item.start is None else item.start
+            final = to_datetime(item.stop) if isinstance(item.stop,
+                                                         str) else self.final_datetime if item.stop is None else item.stop
             if isinstance(initial, datetime) and isinstance(final, datetime):
-                return Timeseries(self.__get_samples(initial, final), True, self.__sampling_frequency, self.__units, self.__name)
+                return self.__new(segments=self.__get_samples(initial, final))
             else:
                 raise IndexError("Index types not supported. Give a slice of datetimes (can be in string format).")
 
@@ -226,7 +613,8 @@ class Timeseries():
                     raise IndexError("Index types not supported. Give a tuple of datetimes (can be in string format).")
             return tuple(res)
 
-        if isinstance(item, DateTimeRange):  # This is not publicly documented. Only Biosignal sends DateTimeRanges, when it is dealing with Events.
+        if isinstance(item,
+                      DateTimeRange):  # This is not publicly documented. Only Biosignal sends DateTimeRanges, when it is dealing with Events.
             # First, trim the start and end limits of the interval.
             start, end = None, None
             for subdomain in self.domain:  # ordered subdomains
@@ -236,170 +624,87 @@ class Timeseries():
                         start = intersection.start_datetime
                     end = intersection.end_datetime
                 elif start is not None:  # if there's no intersection with further subdomains and start was already found...
-                    break  # ... then, the end was already found
+                    break  # ... then, the end was already reached
             if start is None and end is None:
                 return None
             else:
                 return self[start:end]
 
-        raise IndexError("Index types not supported. Give a datetime (can be in string format), a slice or a tuple of those.")
-
-    def __get_sample(self, datetime: datetime) -> float:
-        self.__check_boundaries(datetime)
-        for segment in self.__segments:  # finding the first Segment
-            if datetime in segment:
-                return segment[int((datetime - segment.initial_datetime).total_seconds() * self.sampling_frequency)]
-        raise IndexError("Datetime given is in not defined in this Timeseries.")
-
-    def __get_samples(self, initial_datetime: datetime, final_datetime: datetime) -> List[Segment]:
-        '''Returns the samples between the given initial and end datetimes.'''
-        self.__check_boundaries(initial_datetime)
-        self.__check_boundaries(final_datetime)
-        res_segments = []
-        for i in range(len(self.__segments)):  # finding the first Segment
-            segment = self.__segments[i]
-            if initial_datetime in segment:
-                if final_datetime <= segment.final_datetime:
-                    samples = segment[int((initial_datetime - segment.initial_datetime).total_seconds()*self.sampling_frequency):int((final_datetime - segment.initial_datetime).total_seconds()*self.sampling_frequency)]
-                    res_segments.append(Timeseries.Segment(samples, initial_datetime, self.__sampling_frequency, segment.is_filtered))
-                    return res_segments
-                else:
-                    samples = segment[int((initial_datetime - segment.initial_datetime).total_seconds()*self.sampling_frequency):]
-                    res_segments.append(Timeseries.Segment(samples, initial_datetime, self.__sampling_frequency, segment.is_filtered))
-                    for j in range(i+1, len(self.__segments)):  # adding the remaining samples, until the last Segment is found
-                        segment = self.__segments[j]
-                        if final_datetime <= segment.final_datetime:
-                            samples = segment[:int((final_datetime - segment.initial_datetime).total_seconds()*self.sampling_frequency)]
-                            res_segments.append(Timeseries.Segment(samples, segment.initial_datetime, self.__sampling_frequency, segment.is_filtered))
-                            return res_segments
-                        else:
-                            samples = segment[:]
-                            res_segments.append(Timeseries.Segment(samples, segment.initial_datetime, self.__sampling_frequency, segment.is_filtered))
-
-    def __check_boundaries(self, datetime_or_range: datetime | DateTimeRange) -> None:
-        intersects = False
-        if isinstance(datetime_or_range, datetime):
-            for subdomain in self.domain:
-                if datetime_or_range in subdomain:
-                    intersects = True
-                    break
-            if not intersects:
-                raise IndexError(f"Datetime given is outside of Timeseries domain, {' U '.join([f'[{subdomain.start_datetime}, {subdomain.end_datetime}[' for subdomain in self.domain])}.")
-
-        elif isinstance(datetime_or_range, DateTimeRange):
-            for subdomain in self.domain:
-                if subdomain.is_intersection(datetime_or_range):
-                    intersects = True
-                    break
-            if not intersects:
-                raise IndexError(f"Interval given is outside of Timeseries domain, {' U '.join([f'[{subdomain.start_datetime}, {subdomain.end_datetime}[' for subdomain in self.domain])}.")
-
-
-    # Operations to the samples
+        raise IndexError(
+            "Index types not supported. Give a datetime (can be in string format), a slice or a tuple of those.")
 
     def __iadd__(self, other):
         '''The built-in increment operation (+=) concatenates one Timeseries to the end of another.'''
         if isinstance(other, Timeseries):
-            if other.initial_datetime < self.__final_datetime:
-                raise ArithmeticError("The second Timeseries must start after the first one ends ({} + {}).".format(self.__initial_datetime, other.final_datetime))
-            if other.sampling_frequency != self.__sampling_frequency:
-                raise ArithmeticError("Both Timeseries must have the same sampling frequency ({} and {}).".format(self.__sampling_frequency, other.sampling_frequency))
+            if other.initial_datetime < self.final_datetime:
+                raise ArithmeticError(
+                    "The second Timeseries must start after the first one ends ({} + {}).".format(self.initial_datetime,
+                                                                                                  other.final_datetime))
+            if other.sampling_frequency != self.sampling_frequency:
+                raise ArithmeticError("Both Timeseries must have the same sampling frequency ({} and {}).".format(
+                    self.__sampling_frequency, other.sampling_frequency))
             if other.units is not None and self.__units is not None and other.units != self.__units:
-                raise ArithmeticError("Both Timeseries must have the same units ({} and {}).".format(self.__units, other.units))
-            self.__segments += other.segments # gets a list of all other's Segments and concatenates it to the self's one.
+                raise ArithmeticError(
+                    "Both Timeseries must have the same units ({} and {}).".format(self.__units, other.units))
+            self.__segments += other.segments  # gets a list of all other's Segments and concatenates it to the self's one.
             return self
-
-        raise TypeError("Trying to concatenate an object of type {}. Expected type: Timeseries.".format(type(other)))
+        elif isinstance(other, (ndarray, list)):  # Appends more samples to the last Segment
+            assert len(self.__segments) > 0
+            self.__segments[-1] += other
+        else:
+            raise TypeError(
+                "Trying to concatenate an object of type {}. Expected type: Timeseries.".format(type(other)))
 
     def __add__(self, other):
         '''The built-in sum operation (+) adds two Timeseries.'''
         if isinstance(other, Timeseries):
-            if other.initial_datetime < self.__final_datetime:
-                raise ArithmeticError("The second Timeseries must start after the first one ends ({} + {}).".format(self.__initial_datetime, other.final_datetime))
+            if other.initial_datetime < self.final_datetime:
+                raise ArithmeticError(
+                    "The second Timeseries must start after the first one ends ({} + {}).".format(self.initial_datetime,
+                                                                                                  other.final_datetime))
             if other.sampling_frequency != self.__sampling_frequency:
-                raise ArithmeticError("Both Timeseries must have the same sampling frequency ({} and {}).".format(self.__sampling_frequency, other.sampling_frequency))
+                raise ArithmeticError("Both Timeseries must have the same sampling frequency ({} and {}).".format(
+                    self.__sampling_frequency, other.sampling_frequency))
             if other.units is not None and self.__units is not None and other.units != self.__units:
-                raise ArithmeticError("Both Timeseries must have the same units ({} and {}).".format(self.__units, other.units))
+                raise ArithmeticError(
+                    "Both Timeseries must have the same units ({} and {}).".format(self.__units, other.units))
             new_segments = self.__segments + other.segments
-            x = Timeseries(new_segments, True, self.__sampling_frequency, self.units if self.__units is not None else other.units, self.name + ' plus ' + other.name)
-            return x
+            return self.__new(segments=new_segments, units=self.units if self.__units is not None else other.units,
+                              name=other.name)
 
         raise TypeError("Trying to concatenate an object of type {}. Expected type: Timeseries.".format(type(other)))
 
+    # ===================================
+    # Methods
 
-    def trim(self, initial_datetime: datetime, final_datetime: datetime):
-        pass # TODO
+    def append(self, initial_datetime: datetime, samples: ndarray | list | tuple):
+        """
+        Appends a new sequence of samples in a separate Segment.
+        :param initial_datetime: The date and time of the first sample in 'samples'.
+        :param samples: The sequence of samples to add as a separate Segment.
+        :return: None
+        """
+        assert len(self.__segments) > 0
+        if self.__segments[-1].final_datetime > initial_datetime:  # Check for order and overlaps
+            raise AssertionError("Cannot append more samples starting before the ones already existing.")
 
-    def _accept_filtering(self, filter_design:Filter):
-        filter_design._setup(self.__sampling_frequency)
-        for segment in self.__segments:
-            segment._accept_filtering(filter_design)
+        segment = Timeseries.__Segment(array(samples) if not isinstance(samples, ndarray) else samples,
+                                       initial_datetime, self.__sampling_frequency)
+        self.__segments.append(segment)
 
-    def undo_filters(self):
-        for segment in self.__segments:
-            segment._restore_raw()
+        # Check if equally segmented
+        if self.__is_equally_segmented and len(samples) != len(self.__segments[0]):
+            self.__is_equally_segmented = False
 
-    def _resample(self, frequency:float):
-        for segment in self.__segments:
-            segment._resample(old_frequency=self.sampling_frequency, new_frequency=frequency)
-        self.__sampling_frequency = frequency
-
-    def plot_spectrum(self):
-        colors = ('blue', 'green', 'red')
-        n_columns = len(self.__segments)
-        for i in range(n_columns):
-            segment = self.__segments[i]
-            x, y = power_spectrum(signal=segment.samples)
-            plt.plot(x, y, alpha=0.6, linewidth=0.5,
-                     label='From {0} to {1}'.format(segment.initial_datetime, segment.final_datetime))
-
-    def plot(self):
-        xticks, xticks_labels = [], []  # to store the initial and final ticks of each Segment
-        SPACE = int(self.__sampling_frequency) * 2  # the empty space between each Segment
-
-        for i in range(len(self.__segments)):
-            segment = self.__segments[i]
-            x, y = range(len(segment)), segment.samples
-            if i > 0:  # except for the first Segment
-                x = array(x) + (xticks[-1] + SPACE)  # shift right in time
-                plt.gca().axvspan(x[0]-SPACE, x[0], alpha=0.05, color='black')  # add empty space in between Segments
-            plt.gca().plot(x, y, linewidth=0.5)
-
-            xticks += [x[0], x[-1]]  # add positions of the first and last samples of this Segment
-
-            # add datetimes of the first and last samples of this Segment
-            if segment.duration > timedelta(days=1):  # if greater that a day, include dates
-                time_format = "%d-%m-%Y %H:%M:%S"
-            else:  # otherwise, just the time
-                time_format = "%H:%M:%S"
-            xticks_labels += [segment.initial_datetime.strftime(time_format), segment.final_datetime.strftime(time_format)]
-
-        plt.gca().set_xticks(xticks, xticks_labels)
-        plt.tick_params(axis='x', direction='in')
-
-        if self.units is not None:  # override ylabel
-            plt.gca().set_ylabel("Amplitude ({})".format(self.units))
-
-    def _apply_operation(self, operation, **kwargs):
-        for segment in self.__segments:
-            segment._apply_operation(operation, **kwargs)
-
-    def to_array(self):
-        '''
-        Allows to convert Timeseries to numpy.array, only if it contains just one Segment.
-        '''
-        assert len(self.__segments) == 1
-        return array(self.__segments[0].samples)
-
-    def associate(self, events:Event|Collection[Event]|Dict[str, Event]):
-        '''
+    def associate(self, events: Event | Collection[Event] | Dict[str, Event]):
+        """
         Associates an Event with the Timeseries. Events have names that serve as keys. If keys are given,
         i.e. if 'events' is a dict, then the Event names are override.
-        @param events: One or multiple Event objects.
-        @rtype: None
-        '''
+        :param events: One or multiple Event objects.
+        :return: None
+        """
 
-        def __add_event(event:Event):
+        def __add_event(event: Event):
             try:
                 if event.has_onset and not event.has_offset:
                     self.__check_boundaries(event.onset)  # raises IndexError
@@ -408,9 +713,11 @@ class Timeseries():
                 if event.has_onset and event.has_offset:
                     self.__check_boundaries(event.domain)
             except IndexError:
-                raise ValueError(f"Event '{event.name}' is outside of Timeseries domain, {' U '.join([f'[{subdomain.start_datetime}, {subdomain.end_datetime}[' for subdomain in self.domain])}.")
+                raise ValueError(
+                    f"Event '{event.name}' is outside of Timeseries domain, {' U '.join([f'[{subdomain.start_datetime}, {subdomain.end_datetime}[' for subdomain in self.domain])}.")
             if event.name in self.__associated_events:
-                raise NameError(f"There is already another Event named with '{events.name}'. Cannot have two Events with the same name.")
+                raise NameError(
+                    f"There is already another Event named with '{events.name}'. Cannot have two Events with the same name.")
             else:
                 self.__associated_events[event.name] = event
 
@@ -424,23 +731,379 @@ class Timeseries():
             for event in events:
                 __add_event(event)
 
-    def disassociate(self, event_name:str):
+    def disassociate(self, event_name: str):
+        """
+        Dissociate the event named after the given name.
+        :param event_name: The name of the event to dissociate.
+        :return: None
+        :raise NameError: If there is no associated Event with the given name.
+        """
         if event_name in self.__associated_events:
             del self.__associated_events[event_name]
         else:
             raise NameError(f"There's no Event '{event_name}' associated to this Timeseries.")
 
-    def __contains__(self, item):
-        '''Checks if event occurs in Timeseries.'''
-        return item in self.__associated_events
+    def to_array(self):
+        """
+        Converts Timeseries to numpy.ndarray, only if it contains just one Segment.
+        :return: An array with the Timeseries' samples.
+        :rtype: numpy.ndarray
+        """
+        assert len(self.__segments) == 1
+        return array(self.__segments[0].samples)
+
+    # ===================================
+    # INTERNAL USAGE - Convert indexes <-> timepoints && Get Samples
+
+    def __get_sample(self, datetime: datetime) -> float:
+        self.__check_boundaries(datetime)
+        for segment in self.__segments:  # finding the first Segment
+            if datetime in segment:
+                return segment[int((datetime - segment.initial_datetime).total_seconds() * self.sampling_frequency)]
+        raise IndexError("Datetime given is in not defined in this Timeseries.")
+
+    def __get_samples(self, initial_datetime: datetime, final_datetime: datetime) -> List[__Segment]:
+        '''Returns the samples between the given initial and end datetimes.'''
+        self.__check_boundaries(initial_datetime)
+        self.__check_boundaries(final_datetime)
+        res_segments = []
+        for i in range(len(self.__segments)):  # finding the first Segment
+            segment = self.__segments[i]
+            if initial_datetime in segment:
+                if final_datetime <= segment.final_datetime:
+                    trimmed_segment = segment[int((
+                                                          initial_datetime - segment.initial_datetime).total_seconds() * self.sampling_frequency):int(
+                        (final_datetime - segment.initial_datetime).total_seconds() * self.sampling_frequency)]
+                    res_segments.append(trimmed_segment)
+                    return res_segments
+                else:
+                    trimmed_segment = segment[int((
+                                                          initial_datetime - segment.initial_datetime).total_seconds() * self.sampling_frequency):]
+                    res_segments.append(trimmed_segment)
+                    for j in range(i + 1,
+                                   len(self.__segments)):  # adding the remaining samples, until the last Segment is found
+                        segment = self.__segments[j]
+                        if final_datetime <= segment.final_datetime:
+                            trimmed_segment = segment[:int(
+                                (final_datetime - segment.initial_datetime).total_seconds() * self.sampling_frequency)]
+                            res_segments.append(trimmed_segment)
+                            return res_segments
+                        else:
+                            trimmed_segment = segment[:]
+                            res_segments.append(trimmed_segment)
+
+    def __check_boundaries(self, datetime_or_range: datetime | DateTimeRange) -> None:
+        intersects = False
+        if isinstance(datetime_or_range, datetime):
+            for subdomain in self.domain:
+                if datetime_or_range in subdomain:
+                    intersects = True
+                    break
+            if not intersects:
+                raise IndexError(
+                    f"Datetime given is outside of Timeseries domain, {' U '.join([f'[{subdomain.start_datetime}, {subdomain.end_datetime}[' for subdomain in self.domain])}.")
+
+        elif isinstance(datetime_or_range, DateTimeRange):
+            for subdomain in self.domain:
+                if subdomain.is_intersection(datetime_or_range):
+                    intersects = True
+                    break
+            if not intersects:
+                raise IndexError(
+                    f"Interval given is outside of Timeseries domain, {' U '.join([f'[{subdomain.start_datetime}, {subdomain.end_datetime}[' for subdomain in self.domain])}.")
+
+    def _indices_to_timepoints(self, indices: list[list[int]]) -> tuple[datetime]:
+        all_timepoints: list[datetime] = []
+        for index, segment in zip(indices, self.__segments):
+            timepoints = divide(index, self.__sampling_frequency)  # Transform to timepoints
+            all_timepoints += [segment.initial_datetime + timedelta(seconds=tp) for tp in timepoints]  # Append them all
+        return tuple(all_timepoints)
+
+    # ===================================
+    # INTERNAL USAGE - Plots
+
+    def _plot_spectrum(self):
+        colors = ('blue', 'green', 'red')
+        n_columns = len(self.__segments)
+        for i in range(n_columns):
+            segment = self.__segments[i]
+            x, y = power_spectrum(signal=segment.samples)
+            plt.plot(x, y, alpha=0.6, linewidth=0.5,
+                     label='From {0} to {1}'.format(segment.initial_datetime, segment.final_datetime))
+
+    def _plot(self):
+        xticks, xticks_labels = [], []  # to store the initial and final ticks of each Segment
+        SPACE = int(self.__sampling_frequency) * 2  # the empty space between each Segment
+
+        for i in range(len(self.__segments)):
+            segment = self.__segments[i]
+            x, y = range(len(segment)), segment.samples
+            if i > 0:  # except for the first Segment
+                x = array(x) + (xticks[-1] + SPACE)  # shift right in time
+                plt.gca().axvspan(x[0] - SPACE, x[0], alpha=0.05, color='black')  # add empty space in between Segments
+            plt.gca().plot(x, y, linewidth=0.5)
+
+            xticks += [x[0], x[-1]]  # add positions of the first and last samples of this Segment
+
+            # add datetimes of the first and last samples of this Segment
+            if segment.duration > timedelta(days=1):  # if greater that a day, include dates
+                time_format = "%d-%m-%Y %H:%M:%S"
+            else:  # otherwise, just the time
+                time_format = "%H:%M:%S"
+            xticks_labels += [segment.initial_datetime.strftime(time_format),
+                              segment.final_datetime.strftime(time_format)]
+
+        plt.gca().set_xticks(xticks, xticks_labels)
+        plt.tick_params(axis='x', direction='in')
+
+        if self.units is not None:  # override ylabel
+            plt.gca().set_ylabel("Amplitude ({})".format(self.units))
+
+    # ===================================
+    # INTERNAL USAGE - Accept methods
+
+    # General-purpose
+
+    def _apply_operation(self, operation, **kwargs):
+        """
+        Applies operation in-place to every Segment's samples.
+        """
+        for segment in self.__segments:
+            segment._apply_operation(operation, **kwargs)
+
+    def _apply_operation_and_return(self, operation, **kwargs) -> list:
+        """
+        Applies operation out-of-place to every Segment's samples and returns the ordered output of each in a list.
+
+        Procedure 'operation' must receive a ndarray of samples as first argument.
+        It can receive other arguments, which should be passed in '**kwargs'.
+        Procedure output can return whatever, which shall be returned.
+        """
+        res = []
+        for segment in self.__segments:
+            res.append(segment._apply_operation_and_return(operation, **kwargs))
+        return res
+
+    # Purpose-specific
+
+    def _accept_filtering(self, filter_design: Filter):
+        filter_design._setup(self.__sampling_frequency)
+        for segment in self.__segments:
+            segment._accept_filtering(filter_design)
+
+    def _undo_filters(self):
+        for segment in self.__segments:
+            segment._restore_raw()
+
+    def _resample(self, frequency: float):
+        frequency = frequency if isinstance(frequency, Frequency) else Frequency(frequency)
+        for segment in self.__segments:
+            segment._resample(frequency)
+        self.__sampling_frequency = frequency  # The sf of all Segments points to this property in Timeseries. So, this is only changed here.
+
+    # ===================================
+    # INTERNAL USAGE - Make similar copies or itself
+
+    def __copy__(self):
+        """ Creates an exact copy of the Timeseries' contents and returns the new object. """
+        new = type(self)([seg.__copy__() for seg in self.__segments], self.initial_datetime,
+                         self.__sampling_frequency.__copy__(), self.__units,
+                         str(self.name))  # Uses shortcut in __init__
+        new._Timeseries__is_equally_segmented = self.__is_equally_segmented
+        new.associate(self.events)
+        return new
+
+    def __new(self, segments: List[__Segment] = None, sampling_frequency: float = None, units: Unit = None,
+              name: str = None, equally_segmented: bool = None, overlapping_segments: bool = None,
+              events: Collection[Event] = None):
+        """
+        Private Access: For in-class usage, since who uses is aware of Segment.
+
+        Creates a similar copy of the Timeseries' contents and returns the new object.
+        The value of any field can be changed, when explicitly given a new value for it. All others will be copied.
+
+        :param segments: A list of new Segments to substitute. Optional.
+        :param sampling_frequency: A different sampling frequency. Optional.
+        :param units: Different units. Optional.
+        :param name: A different name. Optional.
+        :param equally_segmented: Alter the is_equally_segmented state. Optional.
+        :param overlapping_segments: Opt to instantiate a Timeseries or an OverlappingTimeseries. Optional.
+        :param events: A collections of different Events. Optional.
+
+        :return: A new Timeseries with the given fields changed. All other contents shall remain the same.
+        :rtype: Timeseries | OverlappingTimeseries
+        """
+
+        initial_datetime = self.initial_datetime if segments is None else segments[0].initial_datetime
+        segments = [seg.__copy__() for seg in
+                    self.__segments] if segments is None else segments  # Uses shortcut in __init__
+        sampling_frequency = self.__sampling_frequency if sampling_frequency is None else sampling_frequency if isinstance(
+            sampling_frequency,
+            Frequency) else Frequency(sampling_frequency)
+        units = self.__units if units is None else units
+        name = str(self.__name) if name is None else name
+        equally_segmented = self.__is_equally_segmented if equally_segmented is None else equally_segmented
+        events = self.__associated_events if events is None else events
+
+        if overlapping_segments is None:
+            new = type(self)(segments, initial_datetime, sampling_frequency, units, name)
+        elif overlapping_segments is True:
+            new = OverlappingTimeseries(segments, initial_datetime, sampling_frequency, units, name)
+        else:
+            new = OverlappingTimeseries(segments, initial_datetime, sampling_frequency, units, name)
+
+        new._Timeseries__is_equally_segmented = equally_segmented
+        new.associate(events)
+        return new
+
+    def _new(self, segments_by_time: Dict[datetime, ndarray | list | tuple] = None,
+             sampling_frequency: float = None,
+             units: Unit = None, name: str = None, equally_segmented: bool = None,
+             overlapping_segments: bool = None,
+             events: Collection[Event] = None, rawsegments_by_time: Dict[datetime, ndarray | list | tuple] = None):
+        """
+        Protected Access: For use of this module, since who uses is not aware of Segment.
+
+        Creates a similar copy of the Timeseries' contents and returns the new object.
+        The value of any field can be changed, when explicitly given a new value for it. All others will be copied.
+
+        :param segments_by_time: The sequence of samples to store as separate Segments, keyed by their initial date and time. Optional.
+        :param sampling_frequency: A different sampling frequency. Optional.
+        :param units: Different units. Optional.
+        :param name: A different name. Optional.
+        :param equally_segmented: Alter the is_equally_segmented state. Optional.
+        :param overlapping_segments: Opt to instantiate a Timeseries or an OverlappingTimeseries. Optional.
+        :param events: A collections of different Events. Optional.
+        :param rawsegments_by_time: The sequence of raw samples to associate to the Segments, keyed by their initial date and time. Optional.
+
+        Note: If both 'segments_by_time' and 'rawsegments_by_time' are given, their key sets must be identical.
+
+        :return: A new Timeseries with the given fields changed. All other contents shall remain the same.
+        :rtype: Timeseries | OverlappingTimeseries
+        """
+
+        # Sampling frequency
+        sampling_frequency = self.__sampling_frequency if sampling_frequency is None else sampling_frequency
+
+        if segments_by_time is not None:
+            # Transform dict into Segments
+            segments = []
+            for initial_datetime, samples in segments_by_time.items():
+                seg = Timeseries.__Segment(samples, initial_datetime, sampling_frequency,
+                                           is_filtered=rawsegments_by_time is not None)
+                seg._Segment__raw_samples = rawsegments_by_time[initial_datetime]
+                segments.append(seg)
+        else:
+            # Send nothing
+            segments = None
+
+        return self.__new(segments=segments, sampling_frequency=sampling_frequency, units=units, name=name,
+                          equally_segmented=equally_segmented, overlapping_segments=overlapping_segments,
+                          events=events)
+
+    def _apply_operation_and_new(self, operation, sampling_frequency: float = None, units: Unit = None,
+                                 name: str = None, equally_segmented: bool = None,
+                                 overlapping_segments: bool = None,
+                                 events: Collection[Event] = None, **kwargs):
+        """
+        For outside usage. Who uses is not aware of Segment.
+        Creates new Segments from the existing ones, using Segment._new().
+        """
+        # Sampling frequency
+        sampling_frequency = self.__sampling_frequency if sampling_frequency is None else sampling_frequency
+        # Apply operation
+        all_new_segments = []
+        for segment in self:
+            all_new_segments.append(
+                segment._apply_operation_and_new(operation, sampling_frequency=sampling_frequency, **kwargs))
+        # Get new Timeseries
+        return self.__new(all_new_segments, sampling_frequency=sampling_frequency, units=units, name=name,
+                          equally_segmented=equally_segmented, overlapping_segments=overlapping_segments,
+                          events=events)
+
+    def _segment_and_new(self, method: Callable,
+                         samples_rkey: str, indexes_rkey: str,
+                         iterate_over_each_segment_key: str = None,
+                         initial_datetimes_shift: timedelta = None,
+                         equally_segmented: bool = True,
+                         overlapping_segments: bool = False,
+                         **kwargs):
+        """
+        For internal usage.
+
+        Segments the Timeseries into smaller portions, using any 'method' that follows the following signature.
+
+        Procedure 'method' should receive as first argument the array of samples to partition. It can receive other
+        arguments after that, which should be passed in' **kwargs'.
+        If there is one item in '**kwargs' that has input to be iteratively passed to 'method',
+        indicate its key in 'iterate_over_each_segment_key'.
+
+        Procedure 'method' should return a dictionary of objects, and at least two of them must be:
+        - The arrays of samples destined to be the smaller Segments. Indicate their key in the dict using 'samples_rkey'.
+        - The start indexes of each corresponding smaller Segment. Indicate their key in the dict using 'indexes_rkey'.
+
+        If what 'indexes_rkey' contains are shifted initial indexes, indicate that offset in 'initial_datetimes_shift'.
+
+        If procedure 'method' will return equally segmented partitions, pass equally_segmented=True.
+        If procedure 'method' will return overlapping partitions, pass overlapping_segments=True.
+        """
+
+        def __patition(segment: Timeseries.__Segment, indices=None) -> list:
+            """
+            Indices should be an array of timepoint where to cut, if 'method' does not find them.
+            """
+            load = kwargs
+            if indices is not None:
+                load[iterate_over_each_segment_key] = indices
+            res = method(segment.samples, **load)
+            _, raw_values = method(segment.raw_samples, **load)
+            assert len(res) >= 2
+            assert samples_rkey in res.keys()
+            assert indexes_rkey in res.keys()
+            indexes, values = res[indexes_rkey], res[samples_rkey]
+            assert len(indexes) == len(values)
+            initial_datetimes = [timedelta(seconds=index / self.__sampling_frequency) + segment.initial_datetime for
+                                 index in indexes]
+            if initial_datetimes_shift is not None:
+                initial_datetimes = [idt + initial_datetimes_shift for idt in initial_datetimes]
+                trimmed_segments = [
+                    segment._new(samples=values[i], initial_datetime=initial_datetimes[i], raw_samples=raw_values) for i
+                    in range(len(values))]
+            else:
+                trimmed_segments = [segment._new(samples=values[i], raw_samples=raw_values) for i in range(len(values))]
+
+            return trimmed_segments
+
+        res_trimmed_segments = []
+        if iterate_over_each_segment_key is not None:
+            for segment, indices in zip(self.__segments, kwargs[iterate_over_each_segment_key]):
+                res_trimmed_segments += __patition(segment, indices)
+        else:
+            for segment in self.__segments:
+                res_trimmed_segments += __patition(segment)
+
+        return self.__new(segments=res_trimmed_segments, equally_segmented=equally_segmented,
+                          overlapping_segments=overlapping_segments)
 
 
 class OverlappingTimeseries(Timeseries):
+    """
+    An OverlappingTimeseries is a Timeseries that violates the rule that to each time point of its domain it must
+    correspond one and only one sample. This special kind of Timeseries allows overlapping Segments, although it looses
+    all its interpretational meaning in the context of being successive data points in time. This kind is useful to
+    extract features from biosignals or to train machine learning models.
 
-    def __init__(self, segments: List[Timeseries.Segment], ordered: bool, sampling_frequency: float, units: Unit = None,
-                 name: str = None, equally_segmented=False):
-        ''' Receives a list of overlapping Segments and a sampling frequency common to all Segments.
-        If they are timely ordered, pass ordered=True, otherwise pass ordered=False.
-        Additionally, it can receive the sample units and a name, if needed.'''
+    It inherits all properties of Timeseries and most of its behaviour.
+    In order to have overlapping Segments, indexing an exact timepoint is no longer possible; Although it is legal to
+    index slices. # FIXME
+    """
 
-        super().__init__(segments, ordered, sampling_frequency, units, name, equally_segmented)
+    def __init__(self, samples: ndarray | list | tuple, initial_datetime: datetime, sampling_frequency: float,
+                 units: Unit = None, name: str = None):
+        super().__init__(samples, initial_datetime, sampling_frequency, units, name)
+
+    def append(self, initial_datetime: datetime, samples: ndarray | list | tuple):
+        assert len(self.__segments) > 0
+        segment = Timeseries._Timeseries__Segment(array(samples) if not isinstance(samples, ndarray) else samples,
+                                       initial_datetime, self.__sampling_frequency)
+        self.__segments.append(segment)

--- a/src/biosignals/Unit.py
+++ b/src/biosignals/Unit.py
@@ -69,6 +69,16 @@ class Unit(ABC):
         pass
 
 
+class Unitless(Unit):
+    def __init__(self):
+        super().__init__(multiplier=Multiplier._)
+
+    def short(self):
+        return "(no unit)"
+
+    def convert_to(self, unit):
+        pass
+
 class G(Unit):
     def __init__(self, multiplier=Multiplier._):
         super().__init__(multiplier)

--- a/src/features/FeatureSelector.py
+++ b/src/features/FeatureSelector.py
@@ -13,6 +13,8 @@
 
 from typing import Callable, Dict
 
+from numpy import ndarray
+
 from src.biosignals.Timeseries import Timeseries
 from src.pipeline.PipelineUnit import SinglePipelineUnit
 
@@ -23,7 +25,7 @@ class FeatureSelector(SinglePipelineUnit):
     PIPELINE_OUTPUT_LABELS = {'selected_features': 'timeseries'}
     ART_PATH = 'resources/pipeline_media/feature_selector.png'
 
-    def __init__(self, selection_function: Callable[[Timeseries.Segment], bool], name:str=None):
+    def __init__(self, selection_function: Callable[[ndarray], bool], name:str=None):
         super().__init__(name)
         self.__selection_function = selection_function
 
@@ -33,7 +35,7 @@ class FeatureSelector(SinglePipelineUnit):
         for feature_name in features:
             ts = features[feature_name]
             assert len(ts.segments) == 1  # Feature Timeseries should have only 1 Segment
-            if self.__selection_function(ts.segments[0]):
+            if self.__selection_function(ts.to_array()):
                 selected_features[feature_name] = ts
 
         return selected_features

--- a/src/features/Features.py
+++ b/src/features/Features.py
@@ -15,6 +15,7 @@ from abc import ABC
 from typing import Dict
 
 import numpy as np
+from numpy import ndarray
 
 from src.biosignals.Timeseries import Timeseries
 
@@ -54,13 +55,28 @@ class TimeFeatures(ABC):
     """
 
     @staticmethod
-    def mean(segment:Timeseries.Segment) -> float:
-        return np.mean(segment.samples)
+    def mean(segment:ndarray) -> float:
+        return np.mean(segment)
 
     @staticmethod
-    def variance(segment:Timeseries.Segment) -> float:
-        return np.var(segment.samples)
+    def variance(segment:ndarray) -> float:
+        return np.var(segment)
 
     @staticmethod
-    def deviation(segment:Timeseries.Segment) -> float:
-        return np.std(segment.samples)
+    def deviation(segment:ndarray) -> float:
+        return np.std(segment)
+
+
+class HRVFeatures(ABC):
+
+    @staticmethod
+    def r_indices(segment:ndarray) -> float:
+        from biosppy.signals.tools import get_heart_rate
+        from biosppy.signals.ecg import ssf_segmenter
+
+    @staticmethod
+    def hr(segment:ndarray) -> float:
+        from biosppy.signals.tools import get_heart_rate
+        from biosppy.signals.ecg import ssf_segmenter
+
+

--- a/src/processing/Segmenter.py
+++ b/src/processing/Segmenter.py
@@ -16,7 +16,8 @@ from datetime import timedelta
 from biosppy.signals.tools import windower
 
 from src.pipeline.PipelineUnit import SinglePipelineUnit
-from src.biosignals.Timeseries import Timeseries, OverlappingTimeseries
+from src.biosignals.Timeseries import Timeseries
+from src.biosignals.Frequency import Frequency
 
 
 class Segmenter(SinglePipelineUnit):
@@ -48,7 +49,7 @@ class Segmenter(SinglePipelineUnit):
                 else:
                     raise AssertionError('Framework does not support segmenting non-adjacent segments, unless you want to join them. Try indexing the time period of interest first.')
 
-        sf = timeseries.sampling_frequency
+        sf = Frequency(timeseries.sampling_frequency)
         n_window_length = int(self.window_length.total_seconds()*sf)
         if self.overlap_length is not None:
             n_overlap_length = int(self.overlap_length.total_seconds()*sf)
@@ -56,18 +57,17 @@ class Segmenter(SinglePipelineUnit):
         else:
             n_step = None
 
-        res_trimmed_segments = []
-        for segment in timeseries.segments:
-            indexes, values = windower(segment.samples, n_window_length, n_step, fcn=lambda x:x)  # funcao identidade
-            assert len(indexes) == len(values)
-            start_datetimes = [timedelta(seconds=index/sf) + segment.initial_datetime for index in indexes]
-            trimmed_segments = [Timeseries.Segment(values[i], start_datetimes[i], sf, segment.is_filtered) for i in range(len(values))]
-            res_trimmed_segments += trimmed_segments
 
-        if n_step is None:
-            return Timeseries(res_trimmed_segments, True, sf, timeseries.units, equally_segmented=True,
-                          name=timeseries.name + " segmented " + str(self.window_length) + " +/- " + str(self.overlap_length))
-        else:
-            return OverlappingTimeseries(res_trimmed_segments, True, sf, timeseries.units, equally_segmented=True,
-                          name=timeseries.name + " segmented " + str(self.window_length) + " +/- " + str(self.overlap_length))
+        new = timeseries._segment_and_new(windower, 'values', 'index',
+                                          equally_segmented = True,
+                                          overlapping_segments = n_step is not None,
+                                          # **kwargs
+                                          size = n_window_length,
+                                          step = n_step,
+                                          fcn = lambda x: x  # funcao identidade
+                                          )
+
+        new.name = timeseries.name + " segmented " + str(self.window_length) + " +/- " + str(self.overlap_length)
+
+        return new
 

--- a/src/processing/Segmenter.py
+++ b/src/processing/Segmenter.py
@@ -33,7 +33,7 @@ class Segmenter(SinglePipelineUnit):
         self.window_length = window_length
         self.overlap_length = overlap_length
 
-    def apply(self, timeseries:Timeseries) -> OverlappingTimeseries:
+    def apply(self, timeseries:Timeseries) -> Timeseries:
         # Assert it only has one Segment or that all Segments are adjacent
         if len(timeseries.segments) > 0:
             adjacent = True
@@ -64,6 +64,10 @@ class Segmenter(SinglePipelineUnit):
             trimmed_segments = [Timeseries.Segment(values[i], start_datetimes[i], sf, segment.is_filtered) for i in range(len(values))]
             res_trimmed_segments += trimmed_segments
 
-        return OverlappingTimeseries(res_trimmed_segments, True, sf, timeseries.units, equally_segmented=True,
+        if n_step is None:
+            return Timeseries(res_trimmed_segments, True, sf, timeseries.units, equally_segmented=True,
+                          name=timeseries.name + " segmented " + str(self.window_length) + " +/- " + str(self.overlap_length))
+        else:
+            return OverlappingTimeseries(res_trimmed_segments, True, sf, timeseries.units, equally_segmented=True,
                           name=timeseries.name + " segmented " + str(self.window_length) + " +/- " + str(self.overlap_length))
 

--- a/tests/biosignals/ECG.py
+++ b/tests/biosignals/ECG.py
@@ -24,12 +24,13 @@ class ECGTestCase(unittest.TestCase):
     def test_r_peaks(self):
         rpeaks = self.ecg['V5'].r_timepoints()
         first_10_true_rpeaks = np.array([timedelta(microseconds=872222), timedelta(seconds=1, microseconds=702778), timedelta(seconds=2, microseconds=497222), timedelta(seconds=3, microseconds=294444), timedelta(seconds=4, microseconds=102778), timedelta(seconds=4, microseconds=855556), timedelta(seconds=5, microseconds=722222), timedelta(seconds=6, microseconds=552778), timedelta(seconds=7, microseconds=358333), timedelta(seconds=8, microseconds=166667)])
+        first_10_true_rpeaks += self.ecg.initial_datetime
         self.assertTrue(np.all(rpeaks[:10] == first_10_true_rpeaks))
 
     def test_heartbeats(self):
         heartbeats = self.ecg.heartbeats()
-        print(heartbeats)
-        heartbeats['2000-01-01 00:00:15':'2000-01-01 00:00:45'].plot()
+        #print(heartbeats)
+        #heartbeats['2000-01-01 00:00:15':'2000-01-01 00:00:45'].plot()
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/biosignals/ECG.py
+++ b/tests/biosignals/ECG.py
@@ -1,4 +1,7 @@
 import unittest
+from datetime import timedelta
+
+import numpy as np
 
 from src.biosignals.ECG import ECG
 from src.biosignals.MITDB import MITDB
@@ -10,13 +13,23 @@ class ECGTestCase(unittest.TestCase):
     def setUpClass(cls):
         cls.ecg = ECG('resources/MITDB_DAT_tests', MITDB)
 
-    def test_plotting_summary_biosppy_filtering_default(cls):
-        cls.ecg['2000-01-01 00:00:15':'2000-01-01 00:00:45']['V2'].plot_summary(show=True)
+    def test_plotting_summary_biosppy_filtering_default(self):
+        self.ecg['2000-01-01 00:00:15':'2000-01-01 00:00:45']['V2'].plot_summary(show=True)
 
-    def test_plotting_summary_own_filtering(cls):
-        cls.ecg.filter(FrequencyDomainFilter(FrequencyResponse.FIR, BandType.LOWPASS, cutoff=20, order=4))
-        cls.ecg['2000-01-01 00:00:15':'2000-01-01 00:00:45']['V2'].plot_summary(show=True)
-        cls.ecg.undo_filters()
+    def test_plotting_summary_own_filtering(self):
+        self.ecg.filter(FrequencyDomainFilter(FrequencyResponse.FIR, BandType.LOWPASS, cutoff=20, order=4))
+        self.ecg['2000-01-01 00:00:15':'2000-01-01 00:00:45']['V2'].plot_summary(show=True)
+        self.ecg.undo_filters()
+
+    def test_r_peaks(self):
+        rpeaks = self.ecg['V5'].r_timepoints()
+        first_10_true_rpeaks = np.array([timedelta(microseconds=872222), timedelta(seconds=1, microseconds=702778), timedelta(seconds=2, microseconds=497222), timedelta(seconds=3, microseconds=294444), timedelta(seconds=4, microseconds=102778), timedelta(seconds=4, microseconds=855556), timedelta(seconds=5, microseconds=722222), timedelta(seconds=6, microseconds=552778), timedelta(seconds=7, microseconds=358333), timedelta(seconds=8, microseconds=166667)])
+        self.assertTrue(np.all(rpeaks[:10] == first_10_true_rpeaks))
+
+    def test_heartbeats(self):
+        heartbeats = self.ecg.heartbeats()
+        print(heartbeats)
+        heartbeats['2000-01-01 00:00:15':'2000-01-01 00:00:45'].plot()
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/biosignals/Event.py
+++ b/tests/biosignals/Event.py
@@ -18,7 +18,7 @@ class EventTestCase(unittest.TestCase):
         cls.name2 = 'My other Event'
 
     def setUp(self) -> None:
-        self.timeseries = Timeseries([Timeseries.Segment([1., 2., 3., 4., 5., 6., 7., 8.], self.datetime1, 1.), ], True, 1.)
+        self.timeseries = Timeseries([1., 2., 3., 4., 5., 6., 7., 8.], self.datetime1, 1.)
         self.biosignal = ECG({'x': self.timeseries})
 
     def test_create_event(self):
@@ -170,35 +170,35 @@ class EventTestCase(unittest.TestCase):
     def test_index_biosignal_with_event_period(self):
         event = Event('seizure', self.datetime2, self.datetime3)
         self.biosignal.associate(event)
-        self.assertEqual(self.biosignal['seizure'].segments[0].samples, [3., 4., 5., 6.])
+        self.assertTrue(all(self.biosignal['seizure'].segments[0].samples == [3., 4., 5., 6.]))
 
     def test_index_biosignal_with_event_period_with_padding(self):
         event = Event('seizure', self.datetime2, self.datetime3)
         self.biosignal.associate(event)
-        self.assertEqual(self.biosignal[timedelta(seconds=2):'seizure':timedelta(seconds=1)].segments[0].samples, [1., 2., 3., 4., 5., 6., 7.])
-        self.assertEqual(self.biosignal[2:'seizure':1].segments[0].samples, [1., 2., 3., 4., 5., 6., 7.])
-        self.assertEqual(self.biosignal['seizure':timedelta(seconds=1)].segments[0].samples, [3., 4., 5., 6., 7.])
-        self.assertEqual(self.biosignal['seizure':1].segments[0].samples, [3., 4., 5., 6., 7.])
-        self.assertEqual(self.biosignal[timedelta(seconds=1):'seizure'].segments[0].samples, [2., 3., 4., 5., 6.])
-        self.assertEqual(self.biosignal[1:'seizure'].segments[0].samples, [2., 3., 4., 5., 6.])
+        self.assertTrue(all(self.biosignal[timedelta(seconds=2):'seizure':timedelta(seconds=1)].segments[0].samples == [1., 2., 3., 4., 5., 6., 7.]))
+        self.assertTrue(all(self.biosignal[2:'seizure':1].segments[0].samples == [1., 2., 3., 4., 5., 6., 7.]))
+        self.assertTrue(all(self.biosignal['seizure':timedelta(seconds=1)].segments[0].samples == [3., 4., 5., 6., 7.]))
+        self.assertTrue(all(self.biosignal['seizure':1].segments[0].samples == [3., 4., 5., 6., 7.]))
+        self.assertTrue(all(self.biosignal[timedelta(seconds=1):'seizure'].segments[0].samples == [2., 3., 4., 5., 6.]))
+        self.assertTrue(all(self.biosignal[1:'seizure'].segments[0].samples == [2., 3., 4., 5., 6.]))
 
         event = Event('seizure2', onset=self.datetime2)
         self.biosignal.associate(event)
-        self.assertEqual(self.biosignal[timedelta(seconds=2):'seizure2':timedelta(seconds=1)].segments[0].samples, [1., 2., 3.])
-        self.assertEqual(self.biosignal[2:'seizure2':1].segments[0].samples, [1., 2., 3.])
-        self.assertEqual(self.biosignal['seizure2':timedelta(seconds=2)].segments[0].samples, [3., 4.])
-        self.assertEqual(self.biosignal['seizure2':2].segments[0].samples, [3., 4.])
-        self.assertEqual(self.biosignal[timedelta(seconds=2):'seizure2'].segments[0].samples, [1., 2.])
-        self.assertEqual(self.biosignal[2:'seizure2'].segments[0].samples, [1., 2.])
+        self.assertTrue(all(self.biosignal[timedelta(seconds=2):'seizure2':timedelta(seconds=1)].segments[0].samples == [1., 2., 3.]))
+        self.assertTrue(all(self.biosignal[2:'seizure2':1].segments[0].samples == [1., 2., 3.]))
+        self.assertTrue(all(self.biosignal['seizure2':timedelta(seconds=2)].segments[0].samples == [3., 4.]))
+        self.assertTrue(all(self.biosignal['seizure2':2].segments[0].samples == [3., 4.]))
+        self.assertTrue(all(self.biosignal[timedelta(seconds=2):'seizure2'].segments[0].samples == [1., 2.]))
+        self.assertTrue(all(self.biosignal[2:'seizure2'].segments[0].samples == [1., 2.]))
 
         event = Event('seizure3', offset=self.datetime2)
         self.biosignal.associate(event)
-        self.assertEqual(self.biosignal[timedelta(seconds=2):'seizure3':timedelta(seconds=1)].segments[0].samples, [1., 2., 3.])
-        self.assertEqual(self.biosignal[2:'seizure3':1].segments[0].samples, [1., 2., 3.])
-        self.assertEqual(self.biosignal['seizure3':timedelta(seconds=2)].segments[0].samples, [3., 4.])
-        self.assertEqual(self.biosignal['seizure3':2].segments[0].samples, [3., 4.])
-        self.assertEqual(self.biosignal[timedelta(seconds=2):'seizure3'].segments[0].samples, [1., 2.])
-        self.assertEqual(self.biosignal[2:'seizure3'].segments[0].samples, [1., 2.])
+        self.assertTrue(all(self.biosignal[timedelta(seconds=2):'seizure3':timedelta(seconds=1)].segments[0].samples == [1., 2., 3.]))
+        self.assertTrue(all(self.biosignal[2:'seizure3':1].segments[0].samples == [1., 2., 3.]))
+        self.assertTrue(all(self.biosignal['seizure3':timedelta(seconds=2)].segments[0].samples == [3., 4.]))
+        self.assertTrue(all(self.biosignal['seizure3':2].segments[0].samples == [3., 4.]))
+        self.assertTrue(all(self.biosignal[timedelta(seconds=2):'seizure3'].segments[0].samples == [1., 2.]))
+        self.assertTrue(all(self.biosignal[2:'seizure3'].segments[0].samples == [1., 2.]))
 
 
 if __name__ == '__main__':

--- a/tests/biosignals/HEM.py
+++ b/tests/biosignals/HEM.py
@@ -1,12 +1,11 @@
 import unittest
 from datetime import datetime
-from os import rmdir, mkdir
 
-from src.clinical.BodyLocation import BodyLocation
 from src.clinical.Epilepsy import Epilepsy
 from src.clinical.Patient import Patient, Sex
 from src.biosignals.Unit import *
 from src.biosignals.Timeseries import Timeseries
+from src.biosignals.Frequency import Frequency
 from src.biosignals import (HEM, ECG)
 
 class HEMTestCase(unittest.TestCase):
@@ -24,13 +23,9 @@ class HEMTestCase(unittest.TestCase):
                                                                          [154.6875 , 105.17578,  60.64453]
 
         cls.initial1, cls.initial2 = datetime(2018, 12, 11, 11, 59, 5), datetime(2018, 12, 11, 19, 39, 17)  # 1/1/2022 4PM and 3/1/2022 9AM
-        cls.sf = 256.
-        cls.segmentx1, cls.segmentx2 = Timeseries.Segment(cls.samplesx1, cls.initial1, cls.sf), Timeseries.Segment(cls.samplesx2, cls.initial2, cls.sf)
-        cls.segmenty1, cls.segmenty2 = Timeseries.Segment(cls.samplesy1, cls.initial1, cls.sf), Timeseries.Segment(cls.samplesy2, cls.initial2, cls.sf)
+        cls.sf = Frequency(256.)
         cls.units = Volt(Multiplier.m)
 
-        cls.tsx = Timeseries([cls.segmentx1, cls.segmentx2], True, cls.sf, cls.units)
-        cls.tsy = Timeseries([cls.segmenty1, cls.segmenty2], True, cls.sf, cls.units)
 
         cls.n_samplesx = 56736
         cls.n_samplesy = 56736

--- a/tests/biosignals/HSM.py
+++ b/tests/biosignals/HSM.py
@@ -1,11 +1,11 @@
 import unittest
 from datetime import datetime
-from os import rmdir, mkdir
 
 from src.clinical.Epilepsy import Epilepsy
 from src.clinical.Patient import Patient, Sex
 from src.biosignals.Unit import *
 from src.biosignals.Timeseries import Timeseries
+from src.biosignals.Frequency import Frequency
 from src.biosignals import (HSM, ECG)
 
 class HSMTestCase(unittest.TestCase):
@@ -25,11 +25,8 @@ class HSMTestCase(unittest.TestCase):
                                                                          [0.0001709850882900646, 0.0001709850882900646,
                                                                           0.0001709850882900646]
         cls.initial1, cls.initial2 = datetime(2019, 2, 28, 8, 7, 16), datetime(2019, 2, 28, 10, 7, 31)  # 1/1/2022 4PM and 3/1/2022 9AM
-        cls.sf = 1000
-        cls.segmentx1, cls.segmentx2 = Timeseries.Segment(cls.samplesx1, cls.initial1, cls.sf), \
-                                         Timeseries.Segment(cls.samplesx2, cls.initial2, cls.sf)
-        cls.segmenty1, cls.segmenty2 = Timeseries.Segment(cls.samplesy1, cls.initial1, cls.sf), \
-                                         Timeseries.Segment(cls.samplesy2, cls.initial2, cls.sf)
+        cls.sf = Frequency(1000)
+
         cls.units = Volt(Multiplier.m)
 
         cls.n_samplesx = 12000
@@ -37,8 +34,6 @@ class HSMTestCase(unittest.TestCase):
 
 
         cls.channelx, cls.channely = "POL Ecg", "POL  ECG-"
-        cls.tsx = Timeseries([cls.segmentx1, cls.segmentx2], True, cls.sf, cls.units)
-        cls.tsy = Timeseries([cls.segmenty1, cls.segmenty2], True, cls.sf, cls.units)
 
 
     def verify_data(cls, x):

--- a/tests/biosignals/MITDB.py
+++ b/tests/biosignals/MITDB.py
@@ -3,6 +3,7 @@ from datetime import datetime
 
 from src.biosignals.Unit import *
 from src.biosignals.Timeseries import Timeseries
+from src.biosignals.Frequency import Frequency
 from src.biosignals import (MITDB, ECG)
 
 class MITDBTestCase(unittest.TestCase):
@@ -13,9 +14,7 @@ class MITDBTestCase(unittest.TestCase):
 
         self.samplesy, self.samplesx = [0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.215, 0.235, 0.24, 0.24, 0.245, 0.265], [-0.15, -0.15, -0.15, -0.15, -0.15, -0.15, -0.15, -0.15, -0.145, -0.135, -0.11, -0.08, -0.04, 0.0, 0.125]
         self.initial = datetime(2000, 1, 1, 0, 0, 0)  # 1/1/2000 0 AM
-        self.sf = 360
-        self.segmentx, self.segmenty = Timeseries.Segment(self.samplesx, self.initial, self.sf), \
-                                    Timeseries.Segment(self.samplesy, self.initial, self.sf)
+        self.sf = Frequency(360)
         self.units = Volt(Multiplier.m)
 
         self.n_samplesx = 650000

--- a/tests/biosignals/MultimodalBiosignal.py
+++ b/tests/biosignals/MultimodalBiosignal.py
@@ -25,9 +25,9 @@ class MultimodalBiosignalTestCase(unittest.TestCase):
         cls.samples1 = [506.0, 501.0, 497.0, 374.5, 383.4, 294.2]
         cls.samples2 = [502.0, 505.0, 505.0, 924.3, 293.4, 383.5]
         cls.samples3 = [527.0, 525.0, 525.0, 849.2, 519.5, 103.4]
-        cls.ts1 = Timeseries([Timeseries.Segment(cls.samples1, cls.initial1, cls.sf), ], True, cls.sf, Volt(Multiplier.m))
-        cls.ts2 = Timeseries([Timeseries.Segment(cls.samples2, cls.initial1, cls.sf), ], True, cls.sf, Volt(Multiplier.m))
-        cls.ts3 = Timeseries([Timeseries.Segment(cls.samples3, cls.initial1, cls.sf), ], True, cls.sf, Volt(Multiplier.m))
+        cls.ts1 = Timeseries(cls.samples1, cls.initial1, cls.sf, Volt(Multiplier.m))
+        cls.ts2 = Timeseries(cls.samples2, cls.initial1, cls.sf, Volt(Multiplier.m))
+        cls.ts3 = Timeseries(cls.samples3, cls.initial1, cls.sf, Volt(Multiplier.m))
 
         cls.ecg1 = ECG({'V1': cls.ts1, 'V2': cls.ts2}, HSM, cls.patient, BodyLocation.CHEST, name='Ecg from Hospital')
         cls.ecg2 = ECG({'Band': cls.ts3, }, Sense, cls.patient, BodyLocation.CHEST, name='Ecg from Band')

--- a/tests/biosignals/Timeseries.py
+++ b/tests/biosignals/Timeseries.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 
 from src.biosignals.Unit import *
 from src.biosignals.Timeseries import Timeseries
+from src.biosignals.Frequency import Frequency
 
 
 class TimeseriesTestCase(unittest.TestCase):
@@ -10,114 +11,124 @@ class TimeseriesTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.samples1, cls.samples2 = [0.34, 2.12, 3.75], [1.34, 3.12, 4.75]
-        cls.initial1, cls.initial2 = datetime(2022, 1, 1, 16, 0, 0), datetime(2022, 1, 3, 9, 0,
-                                                                                0)  # 1/1/2022 4PM and 3/1/2022 9AM
-        cls.sf = 64
-        cls.segment1, cls.segment2 = Timeseries.Segment(cls.samples1, cls.initial1, cls.sf), Timeseries.Segment(
-            cls.samples2, cls.initial2, cls.sf)
+        cls.initial1, cls.initial2 = datetime(2022, 1, 1, 16, 0, 0), datetime(2022, 1, 3, 9, 0, 0)  # 1/1/2022 4PM and 3/1/2022 9AM
+        cls.sf = Frequency(1.0)
         cls.units = Volt(Multiplier.m)
         cls.name = "Test Timeseries 1"
 
-    def verify_metadata(cls, ts: Timeseries):
-        cls.assertEqual(ts.sampling_frequency, cls.sf)
-        cls.assertEqual(ts.units, cls.units)
-        cls.assertEqual(ts.name, cls.name)
+    def verify_metadata(self, ts: Timeseries):
+        self.assertEqual(ts.sampling_frequency, self.sf)
+        self.assertEqual(ts.units, self.units)
+        self.assertEqual(ts.name, self.name)
 
-    def test_create_contiguous_timeseries(cls):
-        '''A contiguous Timeseries is one where all the samples were acquired at each sampling interval. There were no acquisition interruptions on purpose.'''
-        ts = Timeseries([cls.segment1, ], True, cls.sf, cls.units, cls.name)
-        cls.assertEqual(len(ts), len(cls.samples1))
-        cls.verify_metadata(ts)
-        cls.assertEqual(ts.initial_datetime, cls.initial1)
-        cls.assertEqual(ts.final_datetime, cls.initial1 + timedelta(seconds=len(cls.samples1) / cls.sf))
+    def test_create_contiguous_timeseries(self):
+        '''A contiguous Timeseries is one where all the samples were acquired at each sampling interval. There were no acquisition interruptions.'''
+        ts = Timeseries(self.samples1, self.initial1, self.sf, self.units, self.name)
+        self.assertEqual(len(ts), len(self.samples1))
+        self.verify_metadata(ts)
+        self.assertEqual(ts.initial_datetime, self.initial1)
+        self.assertEqual(ts.final_datetime, self.initial1 + timedelta(seconds=len(self.samples1) / self.sf))
 
-    def test_create_discontiguous_timeseries(cls):
+    def test_create_discontiguous_timeseries(self):
         '''A discontiguous Timeseries is one with interruptions between some Segments of samples. Segments are not adjacent in time.'''
-        ts = Timeseries([cls.segment1, cls.segment2], True, cls.sf, cls.units, cls.name)
-        cls.assertEqual(len(ts), len(cls.samples1) + len(cls.samples2))
-        cls.verify_metadata(ts)
-        cls.assertEqual(ts.initial_datetime, cls.initial1)
-        cls.assertEqual(ts.final_datetime, cls.initial2 + timedelta(seconds=len(cls.samples2) / cls.sf))
+        ts = Timeseries.withDiscontiguousSegments({self.initial1: self.samples1, self.initial2: self.samples2}, self.sf, self.units, self.name)
+        self.assertEqual(len(ts), len(self.samples1) + len(self.samples2))
+        self.verify_metadata(ts)
+        self.assertEqual(ts.initial_datetime, self.initial1)
+        self.assertEqual(ts.final_datetime, self.initial2 + timedelta(seconds=len(self.samples2) / self.sf))
 
-    def test_create_not_ordered_discontiguous_timeseries(cls):
+    def test_create_not_ordered_discontiguous_timeseries(self):
         '''A discontiguous Timeseries is one with interruptions between some Segments of samples. Segments are not adjacent in time.'''
-        ts = Timeseries([cls.segment2, cls.segment1], False, cls.sf, cls.units, cls.name)
-        cls.assertEqual(len(ts), len(cls.samples1) + len(cls.samples2))
-        cls.verify_metadata(ts)
-        cls.assertEqual(ts.initial_datetime, cls.initial1)
-        cls.assertEqual(ts.final_datetime, cls.initial2 + timedelta(seconds=len(cls.samples2) / cls.sf))
+        ts = Timeseries.withDiscontiguousSegments({self.initial2: self.samples2, self.initial1: self.samples1}, self.sf, self.units, self.name)
+        self.assertEqual(len(ts), len(self.samples1) + len(self.samples2))
+        self.verify_metadata(ts)
+        self.assertEqual(ts.initial_datetime, self.initial1)
+        self.assertEqual(ts.final_datetime, self.initial2 + timedelta(seconds=len(self.samples2) / self.sf))
 
-    def test_set_name(cls):
-        ts = Timeseries([cls.segment1, ], True, cls.sf, name=cls.name)
-        cls.assertEqual(ts.name, cls.name)
+    def test_create_overlapping_discontiguous_timeseries_raises_error(self):
+        with self.assertRaises(AssertionError):
+            ts = Timeseries.withDiscontiguousSegments({self.initial2: self.samples2, self.initial2+timedelta(seconds=1): self.samples1}, self.sf, self.units, self.name)
+
+    def test_append_more_discontiguous_segments(self):
+        ts = Timeseries(self.samples1, self.initial1, self.sf, self.units, self.name)
+        self.verify_metadata(ts)
+        self.assertEqual(len(ts), len(self.samples1))
+        self.assertEqual(ts.initial_datetime, self.initial1)
+        self.assertEqual(ts.final_datetime, self.initial1 + timedelta(seconds=len(self.samples1) / self.sf))
+
+        ts.append(self.initial2, self.samples2)
+        self.verify_metadata(ts)
+        self.assertEqual(len(ts), len(self.samples1) + len(self.samples2))
+        self.assertEqual(ts.initial_datetime, self.initial1)
+        self.assertEqual(ts.final_datetime, self.initial2 + timedelta(seconds=len(self.samples2) / self.sf))
+
+    def test_set_name(self):
+        ts = Timeseries(self.samples1, self.initial1, self.sf, name=self.name)
+        self.assertEqual(ts.name, self.name)
         ts.name = "New Name"
-        cls.assertEqual(ts.name, "New Name")
+        self.assertEqual(ts.name, "New Name")
 
-    def test_indexing_one(cls):
-        ts = Timeseries([cls.segment1, cls.segment2], True, cls.sf)
+    def test_indexing_one(self):
+        ts = Timeseries.withDiscontiguousSegments({self.initial1: self.samples1, self.initial2: self.samples2}, self.sf)
 
         # These timepoints have samples
-        cls.assertEqual(ts[cls.initial1 + timedelta(seconds=0 / cls.sf)], cls.samples1[0])
-        cls.assertEqual(ts[cls.initial1 + timedelta(seconds=1 / cls.sf)], cls.samples1[1])
-        cls.assertEqual(ts[cls.initial1 + timedelta(seconds=2 / cls.sf)], cls.samples1[2])
-        cls.assertEqual(ts[cls.initial2 + timedelta(seconds=0 / cls.sf)], cls.samples2[0])
-        cls.assertEqual(ts[cls.initial2 + timedelta(seconds=1 / cls.sf)], cls.samples2[1])
-        cls.assertEqual(ts[cls.initial2 + timedelta(seconds=2 / cls.sf)], cls.samples2[2])
+        self.assertEqual(ts[self.initial1 + timedelta(seconds=0 / self.sf)], self.samples1[0])
+        self.assertEqual(ts[self.initial1 + timedelta(seconds=1 / self.sf)], self.samples1[1])
+        self.assertEqual(ts[self.initial1 + timedelta(seconds=2 / self.sf)], self.samples1[2])
+        self.assertEqual(ts[self.initial2 + timedelta(seconds=0 / self.sf)], self.samples2[0])
+        self.assertEqual(ts[self.initial2 + timedelta(seconds=1 / self.sf)], self.samples2[1])
+        self.assertEqual(ts[self.initial2 + timedelta(seconds=2 / self.sf)], self.samples2[2])
 
         # These timepoints do not have samples
-        with cls.assertRaises(IndexError):
-            x = ts[cls.initial2 - timedelta(seconds=10)]  # in the middle of the two segments
-        with cls.assertRaises(IndexError):
-            x = ts[cls.initial1 - timedelta(seconds=10)]  # before the first segment
+        with self.assertRaises(IndexError):
+            x = ts[self.initial2 - timedelta(seconds=10)]  # in the middle of the two segments
+        with self.assertRaises(IndexError):
+            x = ts[self.initial1 - timedelta(seconds=10)]  # before the first segment
 
-    def test_indexing_multiple(cls):
-        ts = Timeseries([cls.segment1, cls.segment2], True, cls.sf)
+    def test_indexing_multiple(self):
+        ts = Timeseries.withDiscontiguousSegments({self.initial1: self.samples1, self.initial2: self.samples2}, self.sf)
 
         # These timepoints have samples
-        cls.assertEqual(
-            ts[cls.initial1 + timedelta(seconds=0 / cls.sf), cls.initial2 + timedelta(seconds=1 / cls.sf)],
-            (cls.samples1[0], cls.samples2[1]))
+        self.assertEqual(
+            ts[self.initial1 + timedelta(seconds=0 / self.sf), self.initial2 + timedelta(seconds=1 / self.sf)],
+            (self.samples1[0], self.samples2[1]))
 
-    def test_indexing_slices(cls):
-        ts = Timeseries([cls.segment1, cls.segment2], True, cls.sf)
+    def test_indexing_slices(self):
+        ts = Timeseries.withDiscontiguousSegments({self.initial1: self.samples1, self.initial2: self.samples2}, self.sf)
 
         # Case A: Indexing on the same Segments
-        cls.assertEqual(
-            ts[cls.initial1 + timedelta(seconds=0 / cls.sf): cls.initial1 + timedelta(seconds=3 / cls.sf)].segments[0][:],
-            cls.samples1[0:3])
-        cls.assertEqual(
-            ts[cls.initial2 + timedelta(seconds=0 / cls.sf): cls.initial2 + timedelta(seconds=3 / cls.sf)].segments[0][:],
-            cls.samples2[0:3])
+        self.assertEqual(ts[self.initial1 + timedelta(seconds=0 / self.sf): self.initial1 + timedelta(seconds=3 / self.sf)].segments[0].samples.tolist(), self.samples1[0:3])
+        self.assertEqual(
+            ts[self.initial2 + timedelta(seconds=0 / self.sf): self.initial2 + timedelta(seconds=3 / self.sf)].segments[0].samples.tolist(),
+            self.samples2[0:3])
 
         # Case B: Indexing in multiple Segments
-        x =  ts[cls.initial1 + timedelta(seconds=0 / cls.sf): cls.initial2 + timedelta(seconds=3 / cls.sf)]
-        cls.assertEqual(
-            x.segments[0][:] + x.segments[1][:],
-            cls.samples1 + cls.samples2)
+        x =  ts[self.initial1 + timedelta(seconds=0 / self.sf): self.initial2 + timedelta(seconds=3 / self.sf)]
+        self.assertEqual(x.segments[0].samples.tolist() + x.segments[1].samples.tolist(), self.samples1 + self.samples2)
 
-    def test_concatenate_two_timeseries(cls):
+    def test_concatenate_two_timeseries(self):
         # With the same sampling frequency and units, and on the correct order
-        ts1 = Timeseries([cls.segment1, ], True, cls.sf, cls.units, cls.name)
-        ts2 = Timeseries([cls.segment2, ], True, cls.sf, cls.units, cls.name)
-        cls.assertEqual(len(ts1 + ts2), len(cls.samples1) + len(cls.samples2))
+        ts1 = Timeseries(self.samples1, self.initial1, self.sf, self.units, self.name)
+        ts2 = Timeseries(self.samples2, self.initial2, self.sf, self.units, self.name)
+        self.assertEqual(len(ts1 + ts2), len(self.samples1) + len(self.samples2))
         ts1 += ts2
-        cls.assertEqual(len(ts1), len(cls.samples1) + len(cls.samples2))
+        self.assertEqual(len(ts1), len(self.samples1) + len(self.samples2))
 
         # With different sampling frequencies
-        ts2 = Timeseries([cls.segment2, ], True, cls.sf+1, cls.units, cls.name)
-        with cls.assertRaises(ArithmeticError):
+        ts2 = Timeseries(self.samples2, self.initial2, self.sf+1, self.units, self.name)
+        with self.assertRaises(ArithmeticError):
             ts1 + ts2
             ts1 += ts2
 
         # With different units
-        ts2 = Timeseries([cls.segment2, ], True, cls.sf, G(), cls.name)
-        with cls.assertRaises(ArithmeticError):
+        ts2 = Timeseries(self.samples2, self.initial2, self.sf, G(), self.name)
+        with self.assertRaises(ArithmeticError):
             ts1 + ts2
             ts1 += ts2
 
         # With initial datetime of the latter coming before the final datetime of the former
-        ts2 = Timeseries([cls.segment2, ], True, cls.sf, cls.units, cls.name)
-        with cls.assertRaises(ArithmeticError):
+        ts2 = Timeseries(self.samples2, self.initial2, self.sf, self.units, self.name)
+        with self.assertRaises(ArithmeticError):
             ts2 + ts1
             ts2 += ts1
 

--- a/tests/biosignals/TimeseriesSegment.py
+++ b/tests/biosignals/TimeseriesSegment.py
@@ -2,6 +2,7 @@ import unittest
 from datetime import datetime, timedelta
 
 from src.biosignals.Timeseries import Timeseries
+from src.biosignals.Frequency import Frequency
 
 
 class TimeseriesSegmentTestCase(unittest.TestCase):
@@ -11,16 +12,17 @@ class TimeseriesSegmentTestCase(unittest.TestCase):
         cls.samples1, cls.samples2 = [0.34, 2.12, 3.75], [1.34, 3.12, 4.75],
         cls.initial1, cls.initial2 = datetime(2022, 1, 1, 16, 0), datetime(2022, 1, 3, 9, 0)  # 1/1/2022 4PM and 3/1/2022 9AM
         cls.final1, cls.final2 = datetime(2022, 1, 1, 16, 0, 3), datetime(2022, 1, 3, 9, 0, 3)  # 1/1/2022 4PM and 3/1/2022 9AM
-        cls.sf = 1  # 1 Hz
+        cls.sf = Frequency(1)  # 1 Hz
+        cls.Segment = Timeseries._Timeseries__Segment
 
     def test_create_segment(cls):
-        segment = Timeseries.Segment(cls.samples1, cls.initial1, cls.sf)
-        cls.assertEqual(cls.samples1, segment[:])
+        segment = cls.Segment(cls.samples1, cls.initial1, cls.sf)
+        cls.assertTrue(all(cls.samples1 == segment.samples))
         cls.assertEqual(cls.initial1, segment.initial_datetime)
         cls.assertEqual(cls.final1, segment.final_datetime)
 
     def test_has_sample_of_a_datetime(cls):  # Does datetime x belong to the domain of Segment?
-        segment = Timeseries.Segment(cls.samples1, cls.initial1, cls.sf)
+        segment = cls.Segment(cls.samples1, cls.initial1, cls.sf)
         cls.assertTrue(datetime(2022, 1, 1, 16, 0, 0) in segment)
         cls.assertTrue(datetime(2022, 1, 1, 16, 0, 1) in segment)
         cls.assertTrue(datetime(2022, 1, 1, 16, 0, 2) in segment)
@@ -28,75 +30,75 @@ class TimeseriesSegmentTestCase(unittest.TestCase):
         cls.assertFalse(datetime(2022, 1, 1, 15, 59, 59) in segment)
 
     def test_indexing(cls):
-        segment = Timeseries.Segment(cls.samples1, cls.initial1, cls.sf)
+        segment = cls.Segment(cls.samples1, cls.initial1, cls.sf)
         cls.assertEqual(cls.samples1[0], segment[0])
         cls.assertEqual(cls.samples1[-1], segment[-1])
-        cls.assertEqual(cls.samples1[:1], segment[:1])
-        cls.assertEqual(cls.samples1[1:], segment[1:])
+        cls.assertTrue(all(cls.samples1[:1] == segment[:1].samples))
+        cls.assertTrue(all(cls.samples1[1:] == segment[1:].samples))
 
     def test_get_duration(cls):  # time
-        segment = Timeseries.Segment(cls.samples1, cls.initial1, cls.sf)
+        segment = cls.Segment(cls.samples1, cls.initial1, cls.sf)
         cls.assertEqual(segment.duration, timedelta(seconds=3))
 
     def test_get_length(cls):  # number of samples
-        segment = Timeseries.Segment(cls.samples1, cls.initial1, cls.sf)
+        segment = cls.Segment(cls.samples1, cls.initial1, cls.sf)
         cls.assertEqual(len(segment), len(cls.samples1))
 
     def test_superposition_two_segments(cls):  # True when they comprehend exactly the same time interval
-        segment1 = Timeseries.Segment(cls.samples1, cls.initial1, cls.sf)
-        segment2 = Timeseries.Segment(cls.samples2, cls.initial1, cls.sf)
+        segment1 = cls.Segment(cls.samples1, cls.initial1, cls.sf)
+        segment2 = cls.Segment(cls.samples2, cls.initial1, cls.sf)
         cls.assertTrue(segment1 == segment2)
-        segment3 = Timeseries.Segment(cls.samples2, cls.initial2, cls.sf)
+        segment3 = cls.Segment(cls.samples2, cls.initial2, cls.sf)
         cls.assertFalse(segment2 == segment3)
 
     def test_not_superposition_two_segments(cls):  # True when they do not comprehend exactly the same time interval
-        segment1 = Timeseries.Segment(cls.samples1, cls.initial1, cls.sf)
-        segment2 = Timeseries.Segment(cls.samples2, cls.initial2, cls.sf)
+        segment1 = cls.Segment(cls.samples1, cls.initial1, cls.sf)
+        segment2 = cls.Segment(cls.samples2, cls.initial2, cls.sf)
         cls.assertTrue(segment1 != segment2)
-        segment3 = Timeseries.Segment(cls.samples1, cls.initial2, cls.sf)
+        segment3 = cls.Segment(cls.samples1, cls.initial2, cls.sf)
         cls.assertFalse(segment2 != segment3)
         
     def test_segment_comes_before_another(cls):
-        segment1 = Timeseries.Segment(cls.samples1, cls.initial1, cls.sf)
-        segment2 = Timeseries.Segment(cls.samples2, cls.initial2, cls.sf)
+        segment1 = cls.Segment(cls.samples1, cls.initial1, cls.sf)
+        segment2 = cls.Segment(cls.samples2, cls.initial2, cls.sf)
         cls.assertTrue(segment1 < segment2)
         cls.assertFalse(segment2 < segment1)
-        segment3 = Timeseries.Segment(cls.samples1, cls.initial1+timedelta(seconds=3.1), cls.sf)  # close, but not adjacent
+        segment3 = cls.Segment(cls.samples1, cls.initial1 + timedelta(seconds=3.1), cls.sf)  # close, but not adjacent
         cls.assertTrue(segment1 < segment3)
         cls.assertTrue(segment1 <= segment3)
-        segment4 = Timeseries.Segment(cls.samples1, cls.initial1 + timedelta(seconds=3), cls.sf)  # adjacent
+        segment4 = cls.Segment(cls.samples1, cls.initial1 + timedelta(seconds=3), cls.sf)  # adjacent
         cls.assertFalse(segment1 < segment4)
         cls.assertTrue(segment1 <= segment4)
 
     def test_segment_comes_after_another(cls):
-        segment1 = Timeseries.Segment(cls.samples1, cls.initial1, cls.sf)
-        segment2 = Timeseries.Segment(cls.samples2, cls.initial2, cls.sf)
+        segment1 = cls.Segment(cls.samples1, cls.initial1, cls.sf)
+        segment2 = cls.Segment(cls.samples2, cls.initial2, cls.sf)
         cls.assertTrue(segment2 > segment1)
         cls.assertFalse(segment1 > segment2)
-        segment3 = Timeseries.Segment(cls.samples1, cls.initial1+timedelta(seconds=3.1), cls.sf)  # close, but not adjacent
+        segment3 = cls.Segment(cls.samples1, cls.initial1 + timedelta(seconds=3.1), cls.sf)  # close, but not adjacent
         cls.assertTrue(segment3 > segment1)
         cls.assertTrue(segment3 >= segment1)
-        segment4 = Timeseries.Segment(cls.samples1, cls.initial1 + timedelta(seconds=3), cls.sf)  # adjacent
+        segment4 = cls.Segment(cls.samples1, cls.initial1 + timedelta(seconds=3), cls.sf)  # adjacent
         cls.assertFalse(segment4 > segment1)
         cls.assertTrue(segment4 >= segment1)
 
     def test_segment_overlaps_another(cls):
-        segment1 = Timeseries.Segment(cls.samples1, cls.initial1, cls.sf)
-        segment2 = Timeseries.Segment(cls.samples1, cls.initial1 + timedelta(seconds=1.5), cls.sf)
+        segment1 = cls.Segment(cls.samples1, cls.initial1, cls.sf)
+        segment2 = cls.Segment(cls.samples1, cls.initial1 + timedelta(seconds=1.5), cls.sf)
         cls.assertTrue(segment1.overlaps(segment2))
         cls.assertTrue(segment2.overlaps(segment1))
-        segment3 = Timeseries.Segment(cls.samples1, cls.initial2, cls.sf)
+        segment3 = cls.Segment(cls.samples1, cls.initial2, cls.sf)
         cls.assertFalse(segment1.overlaps(segment3))
         cls.assertFalse(segment3.overlaps(segment1))
-        segment4 = Timeseries.Segment(cls.samples1, cls.initial1 + timedelta(seconds=3), cls.sf)  # adjacent
+        segment4 = cls.Segment(cls.samples1, cls.initial1 + timedelta(seconds=3), cls.sf)  # adjacent
         cls.assertFalse(segment4.overlaps(segment1))
         cls.assertFalse(segment1.overlaps(segment4))
 
     def test_segment_is_contained_in_another(cls):
-        outer_segment = Timeseries.Segment(cls.samples1 + cls.samples2 + cls.samples1, cls.initial1, cls.sf)
-        inner_segment = Timeseries.Segment(cls.samples1, cls.initial1 + timedelta(seconds=4), cls.sf)
+        outer_segment = cls.Segment(cls.samples1 + cls.samples2 + cls.samples1, cls.initial1, cls.sf)
+        inner_segment = cls.Segment(cls.samples1, cls.initial1 + timedelta(seconds=4), cls.sf)
         cls.assertTrue(inner_segment in outer_segment)
-        inner_segment = Timeseries.Segment(cls.samples1, cls.initial2, cls.sf)
+        inner_segment = cls.Segment(cls.samples1, cls.initial2, cls.sf)
         cls.assertFalse(inner_segment in outer_segment)
 
 

--- a/tests/decision/DecisionMaker.py
+++ b/tests/decision/DecisionMaker.py
@@ -11,8 +11,8 @@ class DecisionMakerTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
-        cls.ts1 = Timeseries([Timeseries.Segment([0, 1, 2, 3, 4], datetime.now(), 1), ], True, 1)
-        cls.ts2 = Timeseries([Timeseries.Segment([0, 1, 2, 3, 4, 5], datetime.now(), 1), ], True, 1)
+        cls.ts1 = Timeseries([0, 1, 2, 3, 4], datetime.now(), 1)
+        cls.ts2 = Timeseries([0, 1, 2, 3, 4, 5], datetime.now(), 1)
 
         def binary_decision_function(timeseries: Timeseries) -> bool:
             return len(timeseries) > 5

--- a/tests/features/FeatureExtractor.py
+++ b/tests/features/FeatureExtractor.py
@@ -22,8 +22,10 @@ class FeatureExtractorTestCase(unittest.TestCase):
         cls.n_segments = 2  # each ts has 2 segments of 10 samples
 
         cls.samples = [ [randint(0, 1) for i in range(cls.n_samples)] for j in range(cls.n_segments)]
-        cls.ts = Timeseries([Timeseries.Segment(cls.samples[i], cls.initials[i], cls.sf) for i in range(cls.n_segments)], True, cls.sf, equally_segmented=True)
 
+    def setUp(self):
+        self.ts = Timeseries.withDiscontiguousSegments({self.initials[i]: self.samples[i] for i in range(self.n_segments)},
+                                                      self.sf)
 
     def test_extract_mean(self):
         extractor = FeatureExtractor((TimeFeatures.mean, ), name='My second pipeline unit!')
@@ -37,15 +39,18 @@ class FeatureExtractorTestCase(unittest.TestCase):
             self.assertEqual(features['mean'][self.initials[i]], mean(self.samples[i]))
 
     def test_timeseries_not_equally_segmented_gives_error(self):
-        """Equally segmented means the Timeseries as been processed by a Segmenter.
+        """
+        Equally segmented means the Timeseries as been processed by a Segmenter.
         This is a requirement for the FeatureExtractor needs to compute a new sampling frequency for the features Timeseries.
-        The user can instantiate a Timeseries with equally_segmented=True even though it is not, so they should be aware of what they're doing in that case."""
+        """
+        self.assertTrue(self.ts.is_equally_segmented)
+        self.ts.append(datetime(2000, 1, 1, 0, 1, 0), [2, 3, 7])
+        self.assertFalse(self.ts.is_equally_segmented)
 
-        ts = Timeseries([Timeseries.Segment(list(), self.initial1, self.sf), ], True, self.sf, equally_segmented=False)
         extractor = FeatureExtractor((TimeFeatures.mean,))
 
         with self.assertRaises(AssertionError):
-            features = extractor.apply(ts)
+            features = extractor.apply(self.ts)
 
 
 if __name__ == '__main__':

--- a/tests/features/FeatureSelector.py
+++ b/tests/features/FeatureSelector.py
@@ -3,6 +3,8 @@ from datetime import datetime
 from statistics import mean
 from typing import Dict
 
+from numpy import ndarray
+
 from src.features.FeatureSelector import FeatureSelector
 from src.biosignals.Timeseries import Timeseries
 
@@ -24,14 +26,14 @@ class FeatureSelectorTestCase(unittest.TestCase):
         cls.features = {}
         cls.feature_names = ('mean', 'variance', 'deviation')
         for i in range(cls.n_features):
-            f = Timeseries([Timeseries.Segment(cls.samples[i], cls.initial, cls.sf), ], True, cls.sf)
+            f = Timeseries(cls.samples[i], cls.initial,  cls.sf)
             cls.features[cls.feature_names[i]] = f
 
 
     def test_select_based_on_average_being_higher_than(self):
 
-        def selection_function(segment: Timeseries.Segment) -> bool:
-            if mean(segment.samples) > 0.5:
+        def selection_function(samples: ndarray) -> bool:
+            if mean(samples) > 0.5:
                 print('keep')
                 return True  # A selection function should evaluate some criteria and return True if the feature is to be kept.
 
@@ -43,8 +45,8 @@ class FeatureSelectorTestCase(unittest.TestCase):
         self.assertEqual(len(selected_features), 2)
         self.assertTrue('variance' in selected_features)
         self.assertTrue('deviation' in selected_features)
-        self.assertEqual(selected_features['variance'].segments[0].samples, self.samples[1])
-        self.assertEqual(selected_features['deviation'].segments[0].samples, self.samples[2])
+        self.assertTrue(all(selected_features['variance'].to_array() == self.samples[1]))
+        self.assertTrue(all(selected_features['deviation'].to_array() == self.samples[2]))
 
 
 

--- a/tests/integration/pipeline.py
+++ b/tests/integration/pipeline.py
@@ -35,14 +35,14 @@ class PipelineIntegrationTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         cls.datetime = datetime.now()
-        cls.ts1 = Timeseries([Timeseries.Segment([0, 1, 2, 3, 4, 7, 5], cls.datetime, 1), ], True, 1)
-        cls.ts2 = Timeseries([Timeseries.Segment([0, 1, 2, 3, 4, 5, 8], cls.datetime, 1), ], True, 1)
-        cls.ts3 = Timeseries([Timeseries.Segment([0, 1, 2, 3, 4, 5, 6], cls.datetime, 1), ], True, 1)
-        cls.ts3_segmented = Timeseries([
-            Timeseries.Segment([0, 1], cls.datetime, 1),
-            Timeseries.Segment([2, 3], cls.datetime+timedelta(seconds=2), 1),
-            Timeseries.Segment([4, 5], cls.datetime+timedelta(seconds=4), 1),
-        ], True, 1, equally_segmented=True)
+        cls.ts1 = Timeseries([0, 1, 2, 3, 4, 7, 5], cls.datetime, 1)
+        cls.ts2 = Timeseries([0, 1, 2, 3, 4, 5, 8], cls.datetime, 1)
+        cls.ts3 = Timeseries([0, 1, 2, 3, 4, 5, 6], cls.datetime, 1)
+        cls.ts3_segmented = Timeseries.withDiscontiguousSegments({
+            cls.datetime: [0, 1],
+            cls.datetime + timedelta(seconds=2): [2, 3],
+            cls.datetime + timedelta(seconds=4): [4, 5],
+        }, 1.0)
         cls.ecg_label = 'V5'
         cls.ts1_label = 'x'
         cls.ts2_label = 'y'
@@ -118,7 +118,7 @@ class PipelineIntegrationTests(unittest.TestCase):
         unit2 = FeatureExtractor((TimeFeatures.mean, TimeFeatures.variance))
         unit3 = FeatureSelector(lambda x: x[0] > 0.4)  # random function; it will only select 'mean'
 
-        target = Timeseries([Timeseries.Segment([0, 0, 1], self.datetime, 1.), ], True, 1.)
+        target = Timeseries([0, 0, 1], self.datetime, 1.)
         unit4 = Input('target', target)
         from sklearn.ensemble import GradientBoostingRegressor
         model = SkLearnModel(GradientBoostingRegressor(n_estimators=500, max_depth=4, min_samples_split=5))

--- a/tests/ml/SupervisingTrainer.py
+++ b/tests/ml/SupervisingTrainer.py
@@ -36,9 +36,9 @@ class SupervisingTrainerTestCase(unittest.TestCase):
         n_features = 10  # There are 10 features, which will be mapped to 10 individual Timeseries of 1 Segment
         n_samples = 442  # There are 442 samples for each feature
         # All features represented as Timeseries
-        cls.all_timeseries = [Timeseries([Timeseries.Segment(samples, datetime.today(), 1), ], True, 1) for samples in X]
+        cls.all_timeseries = [Timeseries(samples, datetime.today(), 1.0) for samples in X]
         # Targets represented as a Timeseries
-        cls.targets = Timeseries([Timeseries.Segment(y, datetime.today(), 1), ], True, 1)
+        cls.targets = Timeseries(y, datetime.today(), 1.0)
 
     def test_create_supervising_trainer(self):
         trainer = SupervisingTrainer(self.model, (self.conditions1, ), name='Test Trainer')

--- a/tests/pipeline/Packet.py
+++ b/tests/pipeline/Packet.py
@@ -9,8 +9,8 @@ class PacketTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
-        cls.ts1 = Timeseries([Timeseries.Segment([0, 1, 2, 3, 4], datetime.now(), 1), ], True, 1)
-        cls.ts2 = Timeseries([Timeseries.Segment([0, 1, 2, 3, 4, 5], datetime.now(), 1), ], True, 1)
+        cls.ts1 = Timeseries([0, 1, 2, 3, 4], datetime.now(), 1)
+        cls.ts2 = Timeseries([0, 1, 2, 3, 4, 5], datetime.now(), 1)
 
     def test_create_packet_with_single_timeseries(self):
         packet = Packet(timeseries=self.ts1, other=4)

--- a/tests/pipeline/Pipeline.py
+++ b/tests/pipeline/Pipeline.py
@@ -26,8 +26,8 @@ class PipelineTestCase(unittest.TestCase):
         cls.samples1 = [506.0, 501.0, 497.0, 374.5, 383.4, 294.2]
         cls.samples2 = [502.0, 505.0, 505.0, 924.3, 293.4, 383.5]
         cls.samples3 = [527.0, 525.0, 525.0, 849.2, 519.5, 103.4]
-        cls.ts1 = Timeseries([Timeseries.Segment(cls.samples1, cls.initial1, cls.sf), ], True, cls.sf)
-        cls.ts2 = Timeseries([Timeseries.Segment(cls.samples2, cls.initial1, cls.sf), ], True, cls.sf)
+        cls.ts1 = Timeseries(cls.samples1, cls.initial1, cls.sf)
+        cls.ts2 = Timeseries(cls.samples2, cls.initial1, cls.sf)
         cls.ecg1 = ECG({"a": cls.ts1, "b": cls.ts2})
 
     def test_create_pipeline(self):

--- a/tests/pipeline/PipelineUnitsUnion.py
+++ b/tests/pipeline/PipelineUnitsUnion.py
@@ -35,14 +35,14 @@ class PipelineUnitsUnionTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         cls.datetime = datetime.now()
-        cls.ts1 = Timeseries([Timeseries.Segment([0, 1, 2, 3, 4], cls.datetime, 1), ], True, 1)
-        cls.ts2 = Timeseries([Timeseries.Segment([0, 1, 2, 3, 4, 5], cls.datetime, 1), ], True, 1)
-        cls.ts3 = Timeseries([Timeseries.Segment([0, 1, 2, 3, 4, 5, 6], cls.datetime, 1), ], True, 1)
-        cls.ts3_segmented = Timeseries([
-            Timeseries.Segment([0, 1], cls.datetime, 1),
-            Timeseries.Segment([2, 3], cls.datetime+timedelta(seconds=2), 1),
-            Timeseries.Segment([4, 5], cls.datetime+timedelta(seconds=4), 1),
-                                        ], True, 1, equally_segmented=True)
+        cls.ts1 = Timeseries([0, 1, 2, 3, 4], cls.datetime, 1)
+        cls.ts2 = Timeseries([0, 1, 2, 3, 4, 5], cls.datetime, 1)
+        cls.ts3 = Timeseries([0, 1, 2, 3, 4, 5, 6], cls.datetime, 1)
+        cls.ts3_segmented = Timeseries.withDiscontiguousSegments({
+            cls.datetime: [0, 1],
+            cls.datetime + timedelta(seconds=2): [2, 3],
+            cls.datetime + timedelta(seconds=4): [4, 5],
+            }, 1)
         cls.ts1_label = 'ts1'
         cls.ts2_label = 'ts2'
         cls.ts3_label = 'ts3'

--- a/tests/pipeline/SinglePipelineUnit.py
+++ b/tests/pipeline/SinglePipelineUnit.py
@@ -30,12 +30,12 @@ class SinglePipelineUnitTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         cls.datetime = datetime(2022, 1, 1, 1, 1, 1)
-        cls.ts1 = Timeseries([Timeseries.Segment([0, 1, 2, 3, 4], cls.datetime, 1), ], True, 1)
-        cls.ts2 = Timeseries([Timeseries.Segment([0, 1, 2, 3, 4, 5], datetime.now(), 1), ], True, 1)
-        cls.ts3 = Timeseries([Timeseries.Segment([0, 1], cls.datetime, 1),
-                              Timeseries.Segment([2, 3], cls.datetime+timedelta(seconds=2), 1),
-                              Timeseries.Segment([4, 5], cls.datetime+timedelta(seconds=4), 1),
-                              ], True, 1, equally_segmented=True)
+        cls.ts1 = Timeseries([0, 1, 2, 3, 4], cls.datetime, 1)
+        cls.ts2 = Timeseries([0, 1, 2, 3, 4, 5], datetime.now(), 1)
+        cls.ts3 = Timeseries.withDiscontiguousSegments({cls.datetime: [0, 1],
+                              cls.datetime + timedelta(seconds=2): [2, 3],
+                              cls.datetime + timedelta(seconds=4): [4, 5],
+                                                        }, 1)
         cls.packetA = Packet(timeseries=cls.ts1)
         cls.packetB = Packet(timeseries=(cls.ts1, cls.ts2))
         cls.packetC = Packet(timeseries=cls.ts3)

--- a/tests/processing/Segmenter.py
+++ b/tests/processing/Segmenter.py
@@ -19,9 +19,7 @@ class SegmenterTestCase(unittest.TestCase):
                                                  -0.11, -0.08, -0.04, 0.0, 0.125]
 
         cls.initial = datetime(2000, 1, 1, 0, 0, 0)  # 1/1/2000 0 AM
-        cls.sf = 360
-        cls.segmentx, cls.segmenty = Timeseries.Segment(cls.samplesx, cls.initial, cls.sf), \
-                                       Timeseries.Segment(cls.samplesy, cls.initial+timedelta(days=1), cls.sf)
+        cls.sf = 360.
 
         cls.n_samplesx_trimmed = 649998
         cls.n_samplesy_trimmed = 649998
@@ -73,6 +71,7 @@ class SegmenterTestCase(unittest.TestCase):
             self.assertEqual(segmenty.samples.tolist(), self.samplesy[j:j + segment_length])
 
 
+    """
     def test_timeseries_not_with_adjecent_segments_gives_error(self):
         segmenter = Segmenter(timedelta(milliseconds=10))
 
@@ -83,6 +82,7 @@ class SegmenterTestCase(unittest.TestCase):
 
         #with self.assertRaises(AssertionError):
         #    segmenter.apply(ts_with_gaps)
+    """
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Major Refactor in Biosignal, Timeseries, Segment object management

- '__copy__' methods implemented

- '_new' methods and variations implemented

- Add class 'Frequency'

- Segment has 'sampling_frequency' which points to the one of the respective Timeseries

- Indexing a Segment with slice returns a trimmed Segment

- Timeseries is instantiated with sequence of samples, without outside creation of Segments.

- Add alternative initializer for Timeseries, called 'withDiscontiguousSegments'

- Ability to append more samples to an existing Timeseries (contiguously or discontiguously)

- Add Unitless as a type of Unit

Conclusion: Corrects multiple architecture breaches. Now, each object knows how to duplicate itself and copy its own material; And no entity besides Timeseries knows of the existent of Segments.